### PR TITLE
Aida-RPC check invalid argument

### DIFF
--- a/executor/extension/validator/rpc_comparator.go
+++ b/executor/extension/validator/rpc_comparator.go
@@ -74,7 +74,10 @@ var EvmErrors = map[int][]string{
 	},
 	executionRevertedC: {"execution reverted"},
 
-	invalidArgumentErrCode: {"invalid argument"},
+	invalidArgumentErrCode: {
+		"invalid argument",
+		"cannot unmarshall",
+	},
 }
 
 // comparatorError is returned when state.Data returned by StateDB does not match recorded state.Data
@@ -280,10 +283,7 @@ func compareBalance(result txcontext.Result, data *rpc.RequestAndResults, block 
 	stateBalance := new(big.Int).SetBytes(res)
 
 	if data.Error != nil {
-		if data.Error.Error.Code == internalErrorCode {
-			return newComparatorError(result, stateBalance.Text(16), data.Error.Error.Message, data, block, internalError)
-		}
-		return newComparatorError(result, stateBalance.Text(16), data.Error.Error.Message, data, block, expectedErrorGotResult)
+		return checkUnexpectedError(result, data, block, res)
 	}
 
 	// no error
@@ -313,10 +313,7 @@ func compareTransactionCount(result txcontext.Result, data *rpc.RequestAndResult
 	stateNonce := littleendian.BytesToUint64(res)
 
 	if data.Error != nil {
-		if data.Error.Error.Code == internalErrorCode {
-			return newComparatorError(result, stateNonce, data.Error.Error.Message, data, block, internalError)
-		}
-		return newComparatorError(result, stateNonce, data.Error.Error.Message, data, block, expectedErrorGotResult)
+		return checkUnexpectedError(result, data, block, res)
 	}
 
 	var recordedString string
@@ -388,7 +385,6 @@ func compareCallStateDbResult(result txcontext.Result, res []byte, data *rpc.Req
 	if !ok {
 		msg = fmt.Sprintf("unknown error code: %v", data.Error.Error.Code)
 	} else {
-
 		// we could have potentially recorded a request with invalid arguments
 		// - this is not checked in execution, hence StateDB returns a valid result.
 		// For this we exclude any invalid requests when getting unmatched results
@@ -458,6 +454,21 @@ func compareEVMStateDBError(result txcontext.Result, err error, data *rpc.Reques
 		noMatchingErrors)
 }
 
+// checkUnexpectedError checks error for methods where error is unexpected.
+// Such methods are very unlikely to cause an error in EVM.
+func checkUnexpectedError(result txcontext.Result, data *rpc.RequestAndResults, block int, expectedValue any) *comparatorError {
+	// Return internal code immediately
+	if data.Error.Error.Code == internalErrorCode {
+		return newComparatorError(result, expectedValue, data.Error.Error.Message, data, block, internalError)
+	}
+
+	if data.Error.Error.Code == invalidArgumentErrCode {
+		return nil
+	}
+
+	return newComparatorError(result, expectedValue, data.Error.Error.Message, data, block, expectedErrorGotResult)
+}
+
 // compareEstimateGas compares recorded data for estimateGas method with result from StateDB
 func compareEstimateGas(result txcontext.Result, data *rpc.RequestAndResults, block int) *comparatorError {
 	res, err := result.GetRawResult()
@@ -519,13 +530,8 @@ func compareCode(result txcontext.Result, data *rpc.RequestAndResults, block int
 	res, _ := result.GetRawResult()
 	dbString := hexutil.Encode(res)
 
-	// did we data an error?
 	if data.Error != nil {
-		// internal error?
-		if data.Error.Error.Code == internalErrorCode {
-			return newComparatorError(result, dbString, data.Error.Error, data, block, internalError)
-		}
-		return newComparatorError(result, dbString, data.Error.Error, data, block, expectedErrorGotResult)
+		return checkUnexpectedError(result, data, block, res)
 	}
 
 	var recordedString string
@@ -549,11 +555,7 @@ func compareStorageAt(result txcontext.Result, data *rpc.RequestAndResults, bloc
 	dbString := hexutil.Encode(res)
 
 	if data.Error != nil {
-		// internal error?
-		if data.Error.Error.Code == internalErrorCode {
-			return newComparatorError(result, dbString, data.Error, data, block, internalError)
-		}
-		return newComparatorError(result, dbString, data.Error, data, block, internalError)
+		return checkUnexpectedError(result, data, block, res)
 	}
 
 	var recordedString string


### PR DESCRIPTION
## Description

This PR adds check to `rpcComparator` which makes recorded error 'invalid argument' or 'cannot unmarshal' not fatal.
This error cannot be reproduce by Aida as it is returned by the client when decoding the data inside the json rpc request.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
