### PR TITLE
Update dump-substate to print Protobuf encoded substate

### DIFF
--- a/cmd/util-db/db/dump_substate.go
+++ b/cmd/util-db/db/dump_substate.go
@@ -34,6 +34,7 @@ var SubstateDumpCommand = cli.Command{
 	Flags: []cli.Flag{
 		&utils.WorkersFlag,
 		&utils.AidaDbFlag,
+		&utils.SubstateEncodingFlag,
 	},
 	Description: `
 The aida-vm dump command requires two arguments:
@@ -52,13 +53,22 @@ func substateDumpAction(ctx *cli.Context) error {
 		return err
 	}
 
+	// prepare substate database
 	sdb, err := db.NewReadOnlySubstateDB(cfg.AidaDb)
 	if err != nil {
 		return fmt.Errorf("cannot open aida-db; %w", err)
 	}
 	defer sdb.Close()
 
+	// set encoding type
+	_, err = sdb.SetSubstateEncoding(cfg.SubstateEncoding)
+	if err != nil {
+		return fmt.Errorf("cannot set substate encoding; %w", err)
+	}
+
+	// run substate dump task
 	taskPool := sdb.NewSubstateTaskPool("aida-vm dump", utildb.SubstateDumpTask, cfg.First, cfg.Last, ctx)
 	err = taskPool.Execute()
+
 	return err
 }

--- a/utildb/dump_substate.go
+++ b/utildb/dump_substate.go
@@ -19,7 +19,6 @@ package utildb
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/Fantom-foundation/Substate/db"
 	"github.com/Fantom-foundation/Substate/substate"
@@ -48,7 +47,7 @@ func SubstateDumpTask(block uint64, tx int, recording *substate.Substate, taskPo
 	jbytes, _ = json.MarshalIndent(outputResult, "", " ")
 	out += fmt.Sprintf("Recorded output result:\n%s\n", jbytes)
 
-	log.Println(out)
+	fmt.Println(out)
 
 	return nil
 }


### PR DESCRIPTION
## Description
This PR upgrade `dump-substate` command to print protobuf encoded substate. The command now take `--substate-encoding <pb/rlp>` flag to set the encoding type.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (changes that do NOT affect functionality)
