### PR TITLE
Add ethereum compatible geth processor

### DIFF
--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -44,6 +44,7 @@ import (
 
 	_ "github.com/0xsoniclabs/tosca/go/processor/floria"
 	_ "github.com/0xsoniclabs/tosca/go/processor/geth"
+	_ "github.com/0xsoniclabs/tosca/go/processor/geth_eth"
 	_ "github.com/0xsoniclabs/tosca/go/processor/opera"
 )
 


### PR DESCRIPTION
An ethereum compatible version of the geth processor has been added in tosca, it is added to the available implementations in aida. 

- [x] New feature (non-breaking change which adds functionality)