### PR TITLE
Move state-hash const to correct location

### DIFF
--- a/utils/metadata.go
+++ b/utils/metadata.go
@@ -53,7 +53,6 @@ const (
 	TimestampPrefix         = db.MetadataPrefix + "ti"
 	DbHashPrefix            = db.MetadataPrefix + "md"
 	HasStateHashPatchPrefix = db.MetadataPrefix + "sh"
-	StateHashPrefix         = "dbh"
 )
 
 // merge is determined by what are we merging

--- a/utils/state_hash.go
+++ b/utils/state_hash.go
@@ -33,6 +33,8 @@ import (
 	"github.com/status-im/keycard-go/hexutils"
 )
 
+const StateHashPrefix = "dbh"
+
 type StateHashProvider interface {
 	GetStateHash(blockNumber int) (common.Hash, error)
 }


### PR DESCRIPTION
## Description

`StateHashPrefix` does not belong into metadata const list. 

## Type of change

- [ ] Refactoring (changes that do NOT affect functionality)
