### PR TITLE
Reduce runtime of CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,28 +38,29 @@ pipeline {
             }
         }
 
-        stage('Lint and build') {
+        stage('Run tests') {
             stages {
                 stage('Check formatting') {
                     steps {
-                        script {
-                            currentBuild.description = "Building on ${env.NODE_NAME}"
-                        }
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
                             sh '''diff=`find . \\( -path ./carmen -o -path ./tosca -o -path ./sonic \\) -prune -o -name '*.go' -exec gofmt -s -l {} \\;`
                                   echo $diff
                                   test -z $diff
                                '''
                         }
+                    }
+                }
+
+                stage('Build') {
+                    steps {
+                        script {
+                            currentBuild.description = "Building on ${env.NODE_NAME}"
+                        }
                         sh "git submodule update --init --recursive"
                         sh "make all -j 4"
                     }
                 }
-            }
-        }
 
-        stage('Parallel stages') {
-            parallel {
                 stage('Run unit tests') {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
@@ -94,6 +95,11 @@ pipeline {
                             sh "build/aida-sdb record --cpu-profile cpu-profile-0.dat --trace-file ${TRACEDIR}/trace-0.dat ${AIDADB} 1000 1500"
                             sh "build/aida-sdb record --cpu-profile cpu-profile-1.dat --trace-file ${TRACEDIR}/trace-1.dat ${AIDADB} 1501 2000"
                         }
+                    }
+                }
+
+                stage('aida-sdb replay') {
+                    steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
                             sh "build/aida-sdb replay ${VM} ${STATEDB} ${TMPDB} ${AIDADB} ${PRIME} ${PROFILE} --shadow-db --db-shadow-impl geth --trace-file ${TRACEDIR}/trace-0.dat 1000 1500"
                             sh "build/aida-sdb replay ${VM} ${STATEDB} ${TMPDB} ${AIDADB} ${PRIME} ${PROFILE} --trace-dir ${TRACEDIR} 1000 2000"


### PR DESCRIPTION
## Description

This PR aims to reduce test runtime of CI tests from >30 minutes to 15-20 minutes. It should be noted that build time already takes 10 minutes. This PR only focus on reducing test runtime.