### PR TITLE
Skip empty priming

### DIFF
--- a/cmd/aida-sdb/trace/replay_substate_test.go
+++ b/cmd/aida-sdb/trace/replay_substate_test.go
@@ -28,7 +28,9 @@ import (
 	substatecontext "github.com/0xsoniclabs/aida/txcontext/substate"
 	"github.com/0xsoniclabs/aida/utils"
 	"github.com/0xsoniclabs/substate/substate"
+	"github.com/0xsoniclabs/substate/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
 	"go.uber.org/mock/gomock"
 )
 
@@ -154,6 +156,10 @@ func TestSdbReplaySubstate_TxPrimerIsAddedIfDbImplIsNotMemory(t *testing.T) {
 
 	db.EXPECT().BeginBlock(uint64(0))
 	db.EXPECT().BeginTransaction(uint32(0))
+	db.EXPECT().Exist(common.HexToAddress("0x1")).Return(true)
+	bulkLoad.EXPECT().SetBalance(common.HexToAddress("0x1"), uint256.NewInt(1))
+	bulkLoad.EXPECT().SetNonce(common.HexToAddress("0x1"), uint64(0))
+	bulkLoad.EXPECT().SetCode(common.HexToAddress("0x1"), gomock.Any())
 	db.EXPECT().EndTransaction()
 	db.EXPECT().EndBlock()
 	db.EXPECT().StartBulkLoad(uint64(1)).Return(bulkLoad, nil)
@@ -187,5 +193,11 @@ var testTx = &substate.Substate{
 	},
 	Result: &substate.Result{
 		GasUsed: 1,
+	},
+	InputSubstate: substate.WorldState{
+		types.HexToAddress("0x1"): &substate.Account{Balance: uint256.NewInt(1)},
+	},
+	OutputSubstate: substate.WorldState{
+		types.HexToAddress("0x1"): &substate.Account{Balance: uint256.NewInt(1)},
 	},
 }

--- a/executor/extension/primer/primer.go
+++ b/executor/extension/primer/primer.go
@@ -28,7 +28,6 @@ import (
 	"github.com/0xsoniclabs/aida/utils"
 	"github.com/0xsoniclabs/substate/db"
 	"github.com/0xsoniclabs/substate/substate"
-	"github.com/google/martian/log"
 )
 
 func MakeStateDbPrimer[T any](cfg *utils.Config) executor.Extension[T] {
@@ -164,7 +163,7 @@ func (p *stateDbPrimer[T]) prime(stateDb state.StateDB, aidaDb db.BaseDB) error 
 	// advance from the latest precomputed update-set to the target block
 	// if the first block is 1, target must prime the genesis block
 	if block < p.cfg.First || p.cfg.First-1 == 0 {
-		log.Infof("\tPriming using substate from %v to %v", block, p.cfg.First-1)
+		p.log.Infof("\tPriming using substate from %v to %v", block, p.cfg.First-1)
 		update, deletedAccounts, err := utils.GenerateUpdateSet(block, p.cfg.First-1, p.cfg, aidaDb)
 		if err != nil {
 			return fmt.Errorf("cannot generate update-set; %w", err)

--- a/utils/prime_ctx.go
+++ b/utils/prime_ctx.go
@@ -64,6 +64,9 @@ func (pc *PrimeContext) mayApplyBulkLoad() error {
 
 // PrimeStateDB primes database with accounts from the world state.
 func (pc *PrimeContext) PrimeStateDB(ws txcontext.WorldState, db state.StateDB) error {
+	if ws == nil || ws.Len() == 0 {
+		return nil
+	}
 	numValues := 0 // number of storage values
 	ws.ForEachAccount(func(address common.Address, account txcontext.Account) {
 		numValues += account.GetStorageSize()
@@ -233,6 +236,10 @@ func (pc *PrimeContext) PrimeStateDBRandom(ws txcontext.WorldState, db state.Sta
 
 // SelfDestructAccounts clears storage of all input accounts.
 func (pc *PrimeContext) SelfDestructAccounts(db state.StateDB, accounts []substatetypes.Address) {
+	if accounts == nil || len(accounts) == 0 {
+		return
+	}
+
 	count := 0
 	db.BeginSyncPeriod(0)
 	db.BeginBlock(pc.block)

--- a/utils/statedb.go
+++ b/utils/statedb.go
@@ -27,7 +27,6 @@ import (
 	"github.com/0xsoniclabs/aida/txcontext"
 	"github.com/0xsoniclabs/substate/db"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/google/martian/log"
 )
 
 const (
@@ -167,6 +166,7 @@ func makeNewStateDB(cfg *Config) (state.StateDB, string, error) {
 		stateDb     state.StateDB
 		stateDbPath string
 		tmpDir      string
+		log         = logger.NewLogger(cfg.LogLevel, "StateDB-NewStateDB")
 	)
 
 	// create a temporary working directory


### PR DESCRIPTION
## Description

There is no need to prime if there is nothing to prime with. 

Also currently 2 empty blocks were created as a sideeffect - one for deleted account priming and one for regular priming. This was causing an error if aida-db wasn't empty for block 1 and block 2.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)