### PR TITLE
Do not prime pb when first is block 1

### DIFF
--- a/executor/extension/primer/primer.go
+++ b/executor/extension/primer/primer.go
@@ -62,6 +62,7 @@ func (p *stateDbPrimer[T]) PreRun(_ executor.State[T], ctx *executor.Context) (e
 
 	// RLP encoded substate starts at block 0
 	// whereas protobuf starts at block 1 - this causes miscall to primer
+	// TODO when opera substate is converted from RLP to PB, block 0 should be shifted to block 1
 	if p.cfg.First == 1 && p.cfg.SubstateEncoding == "protobuf" {
 		return nil
 	}

--- a/executor/extension/primer/primer_test.go
+++ b/executor/extension/primer/primer_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 
@@ -407,4 +408,15 @@ func TestStateDbPrimerExtension_ContinuousPrimingFromExistingDb(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestStateDbPrimerExtension_DoesNotPrimePbToBlock1(t *testing.T) {
+	cfg := &utils.Config{}
+	cfg.First = 1
+	cfg.SubstateEncoding = "protobuf"
+	
+	ext := makeStateDbPrimer[any](cfg, nil)
+
+	err := ext.PreRun(executor.State[any]{}, nil)
+	require.NoError(t, err, "prerun must not fail")
 }

--- a/executor/extension/primer/primer_test.go
+++ b/executor/extension/primer/primer_test.go
@@ -414,7 +414,7 @@ func TestStateDbPrimerExtension_DoesNotPrimePbToBlock1(t *testing.T) {
 	cfg := &utils.Config{}
 	cfg.First = 1
 	cfg.SubstateEncoding = "protobuf"
-	
+
 	ext := makeStateDbPrimer[any](cfg, nil)
 
 	err := ext.PreRun(executor.State[any]{}, nil)


### PR DESCRIPTION
## Description

This PR fixes issue with pb encoded substate which incorrectly primed block 1

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (changes that do NOT affect functionality)
- [ ] Adds or updates testing
- [ ] This change requires a documentation update
