### PR TITLE
Add linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,24 @@
+version: "2"
+linters:
+  settings:
+    staticcheck:
+      initialisms: []
+      dot-import-whitelist: []
+      http-status-code-whitelist: []
+      checks:
+        - all
+        # default ignored checks
+        - "-SA9003" # Empty body in an if or else branch.
+        - "-ST1000" # Invalid regular expression.
+        - "-ST1003" # Unsupported argument to functions in 'encoding/binary'.
+        - "-ST1016" # Trapping a signal that cannot be trapped.
+        - "-ST1020" # Using an invalid host:port pair with a 'net.Listen'-related function.
+        - "-ST1021" # Using 'bytes.Equal' to compare two 'net.IP'.
+        - "-ST1022" #
+        - "-ST1023" # Modifying the buffer in an 'io.Writer' implementation.
+formatters:
+  # Enable specific formatter.
+  # Default: [] (uses standard Go formatting)
+  enable:
+    - gofmt
+    - goimports

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,10 +47,7 @@ pipeline {
                 stage('Check formatting') {
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
-                            sh '''diff=`find . \\( -path ./carmen -o -path ./tosca -o -path ./sonic \\) -prune -o -name '*.go' -exec gofmt -s -l {} \\;`
-                                  echo $diff
-                                  test -z $diff
-                               '''
+                            sh 'golangci-lint run ./...'
                         }
                     }
                 }


### PR DESCRIPTION
## Description

This PR introduces the following linters to Aida CI process.
Static analysers
- errcheck
- staticcheck
- unused
- ineffassign
- govet

Format checkers
- go fmt
- go imports


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (changes that do NOT affect functionality)
- [ ] Adds or updates testing
- [ ] This change requires a documentation update
