### PR TITLE
Fix priming for any first block

### DIFF
--- a/executor/extension/primer/primer.go
+++ b/executor/extension/primer/primer.go
@@ -60,10 +60,9 @@ func (p *stateDbPrimer[T]) PreRun(_ executor.State[T], ctx *executor.Context) (e
 		return nil
 	}
 
-	// RLP encoded substate starts at block 0
-	// whereas protobuf starts at block 1 - this causes miscall to primer
-	// TODO when opera substate is converted from RLP to PB, block 0 should be shifted to block 1
-	if p.cfg.First == 1 && p.cfg.SubstateEncoding == "protobuf" {
+	// As different substates start on different blocks (either 0 or 1)
+	// we must check the starting block with the key word "first" with appropriate chainid
+	if p.cfg.First == utils.KeywordBlocks[p.cfg.ChainID]["first"] {
 		return nil
 	}
 

--- a/executor/extension/primer/primer_test.go
+++ b/executor/extension/primer/primer_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 
@@ -52,6 +51,7 @@ func TestStateDbPrimerExtension_PrimingExistingStateDbMissingDbInfo(t *testing.T
 
 	cfg := &utils.Config{}
 	cfg.IsExistingStateDb = true
+	cfg.First = 2
 
 	ext := makeStateDbPrimer[any](cfg, log)
 
@@ -109,16 +109,24 @@ func TestStateDbPrimerExtension_AttemptToPrimeBlockZeroDoesNotFail(t *testing.T)
 	ctrl := gomock.NewController(t)
 	log := logger.NewMockLogger(ctrl)
 
+	tmpStateDb := t.TempDir()
+
 	cfg := &utils.Config{}
 	cfg.SkipPriming = false
-	cfg.StateDbSrc = ""
-	cfg.First = 0
+	cfg.StateDbSrc = tmpStateDb
+	cfg.IsExistingStateDb = true
+	cfg.First = 2
+
+	err := utils.WriteStateDbInfo(tmpStateDb, cfg, 1, common.Hash{}, false)
+	if err != nil {
+		t.Fatalf("cannot write state db info: %v", err)
+	}
 
 	ext := makeStateDbPrimer[any](cfg, log)
 
-	log.EXPECT().Debugf("skipping priming; first priming block %v; first block %v", ^uint64(0), uint64(0))
+	log.EXPECT().Debugf("skipping priming; first priming block %v; first block %v", uint64(1), uint64(2))
 
-	err := ext.PreRun(executor.State[any]{}, &executor.Context{})
+	err = ext.PreRun(executor.State[any]{}, &executor.Context{})
 	if err != nil {
 		t.Errorf("priming should not happen hence should not fail")
 	}
@@ -408,15 +416,4 @@ func TestStateDbPrimerExtension_ContinuousPrimingFromExistingDb(t *testing.T) {
 			})
 		})
 	}
-}
-
-func TestStateDbPrimerExtension_DoesNotPrimePbToBlock1(t *testing.T) {
-	cfg := &utils.Config{}
-	cfg.First = 1
-	cfg.SubstateEncoding = "protobuf"
-
-	ext := makeStateDbPrimer[any](cfg, nil)
-
-	err := ext.PreRun(executor.State[any]{}, nil)
-	require.NoError(t, err, "prerun must not fail")
 }


### PR DESCRIPTION
## Description

This PR fixes any incorrect first block priming for any `substate-encoding`.
#46 Counted on the fact that every `substate-encoding pb` starts on block 1 which in fact is not correct.
This PR solves any future differences for any substate datatase initial block

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
