### PR TITLE
Changes commit of tests in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,7 +157,8 @@ pipeline {
                         dir('eth-test-package') {
                             checkout scmGit(
                                 userRemoteConfigs: [[url: 'https://github.com/ethereum/tests.git']],
-                                branches: [[name: 'develop']]
+                                // Last commit with GeneralStateTests
+                                branches: [[name: '57935b91beceb43b68c772678bd5d8d53409ce34']]
                             )
                         }
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {


### PR DESCRIPTION
## Description

The directories in  tests repo has been restructured. This PR is made as a workaround to continue support CI testing in Aida. The revision of `tests` is fixed to the last commit before restructuring.

## Type of change

Please delete options that are not relevant.

- [x] Refactoring (changes that do NOT affect functionality)
- [x] Adds or updates testing
