### PR TITLE
Clone only necessary codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,8 @@ install-dev-tools:
 	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.2
 
 format:
-	@goimports -w ./utils ./profile ./txcontext ./ethtest ./rpc ./stochastic ./cmd/util-db/compact ./cmd/util-db/info ./cmd/util-db/metadata ./cmd/util-db/merge ./cmd/util-db/validate ./cmd/util-db/generate ./logger ./register
-	@gofmt -s -d -w ./utils ./profile ./txcontext ./ethtest ./rpc ./stochastic ./cmd/util-db/compact ./cmd/util-db/info ./cmd/util-db/metadata ./cmd/util-db/merge ./cmd/util-db/validate ./cmd/util-db/generate ./logger ./register
+	@goimports -w ./utils ./profile ./txcontext ./ethtest ./rpc ./stochastic ./cmd/util-db/compact ./cmd/util-db/info ./cmd/util-db/metadata ./cmd/util-db/merge ./cmd/util-db/validate ./cmd/util-db/generate ./cmd/util-db/clone ./logger ./register
+	@gofmt -s -d -w ./utils ./profile ./txcontext ./ethtest ./rpc ./stochastic ./cmd/util-db/compact ./cmd/util-db/info ./cmd/util-db/metadata ./cmd/util-db/merge ./cmd/util-db/validate ./cmd/util-db/generate ./cmd/util-db/clone ./logger ./register
 
 check:
-	@golangci-lint run -c .golangci.yml ./utils ./profile ./txcontext ./ethtest ./rpc ./stochastic ./cmd/util-db/compact ./cmd/util-db/info ./cmd/util-db/metadata ./cmd/util-db/merge ./cmd/util-db/validate ./cmd/util-db/generate ./logger ./register
+	@golangci-lint run -c .golangci.yml ./utils ./profile ./txcontext ./ethtest ./rpc ./stochastic ./cmd/util-db/compact ./cmd/util-db/info ./cmd/util-db/metadata ./cmd/util-db/merge ./cmd/util-db/validate ./cmd/util-db/generate ./cmd/util-db/clone ./logger ./register

--- a/cmd/util-db/clone/clone_test.go
+++ b/cmd/util-db/clone/clone_test.go
@@ -596,7 +596,7 @@ func TestCloner_CloneCodes_ClonesCodesFromInputAndOutputSubstate(t *testing.T) {
 	require.True(t, ok, "code does not exist")
 }
 
-func TestCloner_PutCode_DoesNotNilAndEmptyCodes(t *testing.T) {
+func TestCloner_PutCode_DoesNotPutNilCode(t *testing.T) {
 	srcPath := t.TempDir()
 	srcDb, err := db.NewDefaultSubstateDB(srcPath)
 	require.NoError(t, err, "failed to create source db")
@@ -604,14 +604,15 @@ func TestCloner_PutCode_DoesNotNilAndEmptyCodes(t *testing.T) {
 	require.NoError(t, err, "failed to set substate encoding")
 
 	// Create one substate with nil code and one with empty code
-	ss1 := createTestSubstate(t, 1, nil, []byte{})
+	ss1 := createTestSubstate(t, 1, nil, []byte{123})
 	err = srcDb.PutSubstate(ss1)
 	require.NoError(t, err, "failed to put substate")
 
 	// PutCode must be called only once for each code
 	ctrl := gomock.NewController(t)
 	dstDb := db.NewMockSubstateDB(ctrl)
-	// nothing is expected
+	// only one code should be put
+	dstDb.EXPECT().PutCode([]byte{123}).Times(1)
 
 	clnr := cloner{
 		cfg: &utils.Config{

--- a/cmd/util-db/clone/clone_test.go
+++ b/cmd/util-db/clone/clone_test.go
@@ -213,7 +213,7 @@ func TestClone_InvalidDbKeys(t *testing.T) {
 			defer func() {
 				err = aidaDb.Close()
 				if err != nil {
-					t.Fatalf("error closing aidaDb %s: %v", tmpDir, err)
+					t.Fatalf("error closing sourceDb %s: %v", tmpDir, err)
 				}
 			}()
 
@@ -559,9 +559,9 @@ func TestCloner_CloneCodes_ClonesCodesFromInputAndOutputSubstate(t *testing.T) {
 			Workers:          1,
 			SubstateEncoding: "protobuf",
 		},
-		aidaDb:  srcDb,
-		cloneDb: dstDb,
-		log:     logger.NewLogger("warn", "CloneCodesTest"),
+		sourceDb: srcDb,
+		cloneDb:  dstDb,
+		log:      logger.NewLogger("warn", "CloneCodesTest"),
 	}
 
 	err = clnr.cloneCodes()
@@ -601,9 +601,9 @@ func TestCloner_PutCode_DoesNotPutNilCode(t *testing.T) {
 			Workers:          1,
 			SubstateEncoding: "protobuf",
 		},
-		aidaDb:  srcDb,
-		cloneDb: dstDb,
-		log:     logger.NewLogger("warn", "CloneCodesTest"),
+		sourceDb: srcDb,
+		cloneDb:  dstDb,
+		log:      logger.NewLogger("warn", "CloneCodesTest"),
 	}
 
 	err = clnr.cloneCodes()
@@ -634,9 +634,9 @@ func TestCloner_CloneCodes_DoesNotCloneDuplicates(t *testing.T) {
 			Workers:          1,
 			SubstateEncoding: "protobuf",
 		},
-		aidaDb:  srcDb,
-		cloneDb: dstDb,
-		log:     logger.NewLogger("warn", "CloneCodesTest"),
+		sourceDb: srcDb,
+		cloneDb:  dstDb,
+		log:      logger.NewLogger("warn", "CloneCodesTest"),
 	}
 
 	err = clnr.cloneCodes()

--- a/cmd/util-db/clone/clone_test.go
+++ b/cmd/util-db/clone/clone_test.go
@@ -175,7 +175,7 @@ func TestClone_InvalidDbKeys(t *testing.T) {
 			name:        "SubstateInvalidDbKey",
 			keyPrefix:   db.SubstateDBPrefix,
 			dbComponent: "substate",
-			expectedErr: "clone failed for SubstateInvalidDbKey: condition emit error; invalid length of substate db key: 5",
+			expectedErr: "clone failed for SubstateInvalidDbKey: cannot clone codes; invalid substate key: [49 115 105 110 118]; invalid length of substate db key: 5",
 		},
 		{
 			name:        "UpdateSetsInvalidDbKey",

--- a/cmd/util-db/clone/clone_test.go
+++ b/cmd/util-db/clone/clone_test.go
@@ -554,3 +554,124 @@ func TestClone_Commands(t *testing.T) {
 		})
 	}
 }
+
+func TestCloner_CloneCodes_ClonesCodesFromInputAndOutputSubstate(t *testing.T) {
+	srcPath := t.TempDir()
+	srcDb, err := db.NewDefaultSubstateDB(srcPath)
+	require.NoError(t, err, "failed to create source db")
+	err = srcDb.SetSubstateEncoding("protobuf")
+	require.NoError(t, err, "failed to set substate encoding")
+
+	ss := createTestSubstate(t, 1)
+	err = srcDb.PutSubstate(ss)
+	require.NoError(t, err, "failed to put substate")
+
+	dstPath := t.TempDir()
+	dstDb, err := db.NewDefaultSubstateDB(dstPath)
+	require.NoError(t, err, "failed to create destination db")
+	err = dstDb.SetSubstateEncoding("protobuf")
+	require.NoError(t, err, "failed to set substate encoding")
+
+	clnr := cloner{
+		cfg: &utils.Config{
+			First:            1,
+			Last:             10,
+			Workers:          1,
+			SubstateEncoding: "protobuf",
+		},
+		aidaDb:  srcDb,
+		cloneDb: dstDb,
+		log:     logger.NewLogger("warn", "CloneCodesTest"),
+	}
+
+	err = clnr.cloneCodes()
+	require.NoError(t, err, "failed to clone codes")
+
+	codeDb := db.MakeDefaultCodeDBFromBaseDB(dstDb)
+	ok, err := codeDb.HasCode(hash.Keccak256Hash([]byte{1}))
+	require.NoError(t, err, "failed to check if code exists")
+	require.True(t, ok, "code does not exist")
+	ok, err = codeDb.HasCode(hash.Keccak256Hash([]byte{2}))
+	require.NoError(t, err, "failed to check if code exists")
+	require.True(t, ok, "code does not exist")
+}
+
+func TestCloner_CloneCodes_DoesNotCloneDuplicates(t *testing.T) {
+	srcPath := t.TempDir()
+	srcDb, err := db.NewDefaultSubstateDB(srcPath)
+	require.NoError(t, err, "failed to create source db")
+	err = srcDb.SetSubstateEncoding("protobuf")
+	require.NoError(t, err, "failed to set substate encoding")
+
+	// Create two identical substates with different tx numbers
+	ss1 := createTestSubstate(t, 1)
+	err = srcDb.PutSubstate(ss1)
+	require.NoError(t, err, "failed to put substate")
+	ss2 := createTestSubstate(t, 2)
+	err = srcDb.PutSubstate(ss2)
+	require.NoError(t, err, "failed to put substate")
+
+	// PutCode must be called only once for each code
+	ctrl := gomock.NewController(t)
+	dstDb := db.NewMockSubstateDB(ctrl)
+	dstDb.EXPECT().PutCode([]byte{1}).MaxTimes(1)
+	dstDb.EXPECT().PutCode([]byte{2}).MaxTimes(1)
+
+	clnr := cloner{
+		cfg: &utils.Config{
+			First:            1,
+			Last:             10,
+			Workers:          1,
+			SubstateEncoding: "protobuf",
+		},
+		aidaDb:  srcDb,
+		cloneDb: dstDb,
+		log:     logger.NewLogger("warn", "CloneCodesTest"),
+	}
+
+	err = clnr.cloneCodes()
+	require.NoError(t, err, "failed to clone codes")
+}
+
+func createTestSubstate(t *testing.T, tx int) *substate.Substate {
+	t.Helper()
+	random := types.Hash{1}
+	to := types.Address{1}
+	return &substate.Substate{
+		InputSubstate: substate.WorldState{
+			types.Address{1}: &substate.Account{
+				Code:    []byte{1},
+				Balance: uint256.NewInt(10),
+				Storage: make(map[types.Hash]types.Hash),
+			},
+		},
+		OutputSubstate: substate.WorldState{
+			types.Address{2}: &substate.Account{
+				Code:    []byte{2},
+				Balance: uint256.NewInt(10),
+				Storage: make(map[types.Hash]types.Hash),
+			},
+		},
+		Env: &substate.Env{
+			Difficulty:  big.NewInt(10),
+			BaseFee:     big.NewInt(10),
+			BlobBaseFee: big.NewInt(10),
+			BlockHashes: make(map[uint64]types.Hash),
+			Random:      &random,
+		},
+		Message: &substate.Message{
+			GasPrice:              big.NewInt(10),
+			To:                    &to,
+			Value:                 big.NewInt(10),
+			AccessList:            make(types.AccessList, 0),
+			GasFeeCap:             big.NewInt(10),
+			GasTipCap:             big.NewInt(10),
+			BlobHashes:            make([]types.Hash, 0),
+			SetCodeAuthorizations: make([]types.SetCodeAuthorization, 0),
+		},
+		Result:      &substate.Result{},
+		Block:       uint64(1),
+		Transaction: tx,
+	}
+}
+

--- a/cmd/util-db/clone/cloner.go
+++ b/cmd/util-db/clone/cloner.go
@@ -504,12 +504,13 @@ func openCloningDbs(aidaDbPath, targetDbPath string) (db.BaseDB, db.BaseDB, erro
 		return nil, nil, fmt.Errorf("cannot set substate encoding; %v", err)
 	}
 
-	// open cloneDbAction
-	cloneDb, err = db.NewDefaultBaseDB(targetDbPath)
+	baseDb, err := db.NewDefaultBaseDB(targetDbPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("targetDb %v; %v", targetDbPath, err)
 	}
 
+	// open clone db
+	cloneDb = db.MakeDefaultSubstateDBFromBaseDB(baseDb)
 	err = cloneDb.SetSubstateEncoding(substateEncoding)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot set substate encoding; %v", err)

--- a/cmd/util-db/clone/cloner.go
+++ b/cmd/util-db/clone/cloner.go
@@ -141,6 +141,9 @@ func (c *cloner) readData() error {
 	}
 
 	err := c.cloneCodes()
+	if err != nil {
+		return fmt.Errorf("cannot clone code; %w", err)
+	}
 	firstDeletionBlock := c.cfg.First
 
 	// update c.cfg.First block before loading deletions and substates, because for utils.CloneType those are necessary to be from last updateset onward
@@ -553,7 +556,7 @@ func (c *cloner) cloneCodes() error {
 
 	}
 	c.log.Noticef("Prefix %v done", db.CodeDBPrefix)
-	return nil
+	return iter.Error()
 }
 
 // putCode puts code into the cloneDb and increments the count

--- a/cmd/util-db/clone/cloner.go
+++ b/cmd/util-db/clone/cloner.go
@@ -551,7 +551,7 @@ func (c *cloner) cloneCodes() error {
 // putCode puts code into the cloneDb and increments the count
 func (c *cloner) putCode(code []byte) error {
 	// skip empty codes
-	if code == nil || len(code) == 0 {
+	if code == nil {
 		return nil
 	}
 	c.count++

--- a/cmd/util-db/clone/cloner.go
+++ b/cmd/util-db/clone/cloner.go
@@ -19,7 +19,6 @@ package clone
 import (
 	"errors"
 	"fmt"
-	"github.com/0xsoniclabs/substate/types"
 	"os"
 	"time"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/0xsoniclabs/aida/utildb/dbcomponent"
 	"github.com/0xsoniclabs/aida/utils"
 	"github.com/0xsoniclabs/substate/db"
+	"github.com/0xsoniclabs/substate/types"
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/syndtr/goleveldb/leveldb"

--- a/cmd/util-db/clone/cloner.go
+++ b/cmd/util-db/clone/cloner.go
@@ -499,7 +499,7 @@ func openCloningDbs(aidaDbPath, targetDbPath string) (db.BaseDB, db.BaseDB, erro
 		return nil, nil, fmt.Errorf("aidaDb %v; %v", aidaDbPath, err)
 	}
 
-	err = aidaDb.SetSubstateEncoding(db.SubstateEncodingSchema(substateEncoding))
+	err = aidaDb.SetSubstateEncoding(substateEncoding)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot set substate encoding; %v", err)
 	}
@@ -511,7 +511,7 @@ func openCloningDbs(aidaDbPath, targetDbPath string) (db.BaseDB, db.BaseDB, erro
 
 	// open clone db
 	cloneDb = db.MakeDefaultSubstateDBFromBaseDB(baseDb)
-	err = cloneDb.SetSubstateEncoding(db.SubstateEncodingSchema(substateEncoding))
+	err = cloneDb.SetSubstateEncoding(substateEncoding)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot set substate encoding; %v", err)
 	}

--- a/cmd/util-db/clone/cloner.go
+++ b/cmd/util-db/clone/cloner.go
@@ -446,7 +446,10 @@ func (c *cloner) stop() {
 // readDataCustom retrieves data from source AidaDb based on given dbComponent
 func (c *cloner) readDataCustom() error {
 	if c.cloneComponent == dbcomponent.Substate || c.cloneComponent == dbcomponent.All {
-		c.read([]byte(db.CodeDBPrefix), 0, nil)
+		err := c.cloneCodes()
+		if err != nil {
+			return fmt.Errorf("cannot clone codes; %w", err)
+		}
 		c.readSubstate()
 	}
 

--- a/cmd/util-db/clone/cloner.go
+++ b/cmd/util-db/clone/cloner.go
@@ -19,9 +19,10 @@ package clone
 import (
 	"errors"
 	"fmt"
-	"github.com/0xsoniclabs/substate/types/hash"
 	"os"
 	"time"
+
+	"github.com/0xsoniclabs/substate/types/hash"
 
 	"github.com/0xsoniclabs/aida/logger"
 	"github.com/0xsoniclabs/aida/utildb"
@@ -55,7 +56,7 @@ type rawEntry struct {
 }
 
 // clone creates aida-db copy or subset - either clone(standalone - containing all necessary data for given range) or patch(containing data only for given range)
-func clone(cfg *utils.Config, aidaDb, cloneDb db.BaseDB, cloneType utils.AidaDbType) error {
+func clone(cfg *utils.Config, aidaDb, cloneDb db.SubstateDB, cloneType utils.AidaDbType) error {
 	var err error
 	log := logger.NewLogger(cfg.LogLevel, "AidaDb clone")
 
@@ -480,7 +481,7 @@ func (c *cloner) readDataCustom() error {
 }
 
 // openCloningDbs prepares aida and target databases
-func openCloningDbs(aidaDbPath, targetDbPath string) (db.BaseDB, db.BaseDB, error) {
+func openCloningDbs(aidaDbPath, targetDbPath string, substateEncoding db.SubstateEncodingSchema) (db.SubstateDB, db.SubstateDB, error) {
 	var err error
 
 	// if source db doesn't exist raise error
@@ -574,7 +575,7 @@ func (c *cloner) cloneCodes() error {
 // putCode puts code into the cloneDb and increments the count
 func (c *cloner) putCode(code []byte) error {
 	// skip empty codes
-	if code == nil || len(code) == 0 {
+	if len(code) == 0 {
 		return nil
 	}
 	c.count++

--- a/cmd/util-db/clone/cloner.go
+++ b/cmd/util-db/clone/cloner.go
@@ -507,11 +507,6 @@ func openCloningDbs(aidaDbPath, targetDbPath string, substateEncoding db.Substat
 		return nil, nil, fmt.Errorf("sourceDb %v; %v", aidaDbPath, err)
 	}
 
-	err = aidaDb.SetSubstateEncoding(substateEncoding)
-	if err != nil {
-		return nil, nil, fmt.Errorf("cannot set substate encoding; %v", err)
-	}
-
 	cloneDb, err = db.NewDefaultSubstateDB(targetDbPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("targetDb %v; %v", targetDbPath, err)

--- a/cmd/util-db/clone/cloner_test.go
+++ b/cmd/util-db/clone/cloner_test.go
@@ -26,8 +26,8 @@ import (
 
 func TestCloner_stop(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockDbSrc := db.NewMockBaseDB(ctrl)
-	mockDbTarget := db.NewMockBaseDB(ctrl)
+	mockDbSrc := db.NewMockSubstateDB(ctrl)
+	mockDbTarget := db.NewMockSubstateDB(ctrl)
 
 	mockDbSrc.EXPECT().Close()
 	mockDbTarget.EXPECT().Close()

--- a/cmd/util-db/clone/cloner_test.go
+++ b/cmd/util-db/clone/cloner_test.go
@@ -34,9 +34,9 @@ func TestCloner_stop(t *testing.T) {
 
 	ch := make(chan any)
 	c := &cloner{
-		aidaDb:  mockDbSrc,
-		cloneDb: mockDbTarget,
-		stopCh:  ch,
+		sourceDb: mockDbSrc,
+		cloneDb:  mockDbTarget,
+		stopCh:   ch,
 	}
 	c.stop()
 	ticker := time.NewTicker(time.Second)

--- a/cmd/util-db/clone/custom.go
+++ b/cmd/util-db/clone/custom.go
@@ -36,6 +36,7 @@ var cloneCustomCommand = cli.Command{
 		&utils.CompactDbFlag,
 		&utils.ValidateFlag,
 		&logger.LogLevelFlag,
+		&utils.SubstateEncodingFlag,
 	},
 	Description: `
 clone custom is a specialized clone tool which copies specific components in aida-db from 
@@ -50,7 +51,7 @@ func cloneCustomAction(ctx *cli.Context) error {
 		return err
 	}
 
-	aidaDb, targetDb, err := openCloningDbs(cfg.AidaDb, cfg.TargetDb)
+	aidaDb, targetDb, err := openCloningDbs(cfg.AidaDb, cfg.TargetDb, cfg.SubstateEncoding)
 	if err != nil {
 		return err
 	}

--- a/cmd/util-db/clone/db.go
+++ b/cmd/util-db/clone/db.go
@@ -35,6 +35,7 @@ var cloneDbCommand = cli.Command{
 		&utils.CompactDbFlag,
 		&utils.ValidateFlag,
 		&logger.LogLevelFlag,
+		&utils.SubstateEncodingFlag,
 	},
 	Description: `
 Creates clone db is used to create subset of aida-db to have more compact database, but still fully usable for desired block range.
@@ -48,7 +49,7 @@ func cloneDbAction(ctx *cli.Context) error {
 		return err
 	}
 
-	aidaDb, targetDb, err := openCloningDbs(cfg.AidaDb, cfg.TargetDb)
+	aidaDb, targetDb, err := openCloningDbs(cfg.AidaDb, cfg.TargetDb, cfg.SubstateEncoding)
 	if err != nil {
 		return err
 	}

--- a/cmd/util-db/clone/patch.go
+++ b/cmd/util-db/clone/patch.go
@@ -38,6 +38,7 @@ var clonePatchCommand = cli.Command{
 		&utils.CompactDbFlag,
 		&utils.ValidateFlag,
 		&logger.LogLevelFlag,
+		&utils.SubstateEncodingFlag,
 	},
 	Description: `
 Creates patch of aida-db for desired block range
@@ -67,7 +68,7 @@ func clonePatchAction(ctx *cli.Context) error {
 		return err
 	}
 
-	aidaDb, targetDb, err := openCloningDbs(cfg.AidaDb, cfg.TargetDb)
+	aidaDb, targetDb, err := openCloningDbs(cfg.AidaDb, cfg.TargetDb, cfg.SubstateEncoding)
 	if err != nil {
 		return err
 	}
@@ -84,7 +85,7 @@ func clonePatchAction(ctx *cli.Context) error {
 }
 
 // createPatchClone creates aida-db clonePatchCommand
-func createPatchClone(cfg *utils.Config, aidaDb, targetDb db.BaseDB, firstEpoch, lastEpoch uint64) error {
+func createPatchClone(cfg *utils.Config, aidaDb, targetDb db.SubstateDB, firstEpoch, lastEpoch uint64) error {
 	var cloneType = utils.PatchType
 	err := clone(cfg, aidaDb, targetDb, cloneType)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR fixes issue with `util-db clone` where we always cloned all of the code hashes. Now only code hashes touched in given block range are cloned

Fixes #57 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
