### PR TITLE
Fix eth-test chainid

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -110,6 +110,7 @@ var EthereumChainIDs = ChainIDs{
 	HoleskyChainID:  "holesky",
 	HoodiChainID:    "hoodi",
 	SepoliaChainID:  "sepolia",
+	EthTestsChainID: "eth-tests",
 }
 
 const (
@@ -1009,5 +1010,6 @@ func ToTitleCase(fork string) string {
 // IsEthereumNetwork checks if the chainID is an Ethereum network - mainnet, holesky, hoodi or sepolia.
 // Special conditions for miner rewards and validation are applied.
 func IsEthereumNetwork(chainID ChainID) bool {
-	return chainID == EthereumChainID || chainID == HoleskyChainID || chainID == HoodiChainID || chainID == SepoliaChainID
+	_, ok := EthereumChainIDs[chainID]
+	return ok
 }

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -807,7 +807,7 @@ func TestUtilsConfig_ToTitleCase_Success(t *testing.T) {
 }
 
 func TestConfigContext_setVmConfig(t *testing.T) {
-	for chainID, name := range RealChainIDs {
+	for chainID, name := range AllowedChainIDs {
 		t.Run(name, func(t *testing.T) {
 			cfg := &Config{ChainID: chainID}
 			ctx := NewConfigContext(cfg, nil)


### PR DESCRIPTION
## Description

This PR fixes incorrectly set `vmCfg` in `configContext` by adding the `EthTestsChainID` to the `EthereumChainIDs` and checking the `IsEthereumNetwork` against this map

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

