### PR TITLE
Introduces Prague fork in Eth-tests

### DIFF
--- a/ethtest/test_case_splitter.go
+++ b/ethtest/test_case_splitter.go
@@ -18,6 +18,7 @@ type Transaction struct {
 }
 
 var usableForks = map[string]struct{}{
+	"Prague":       {},
 	"Cancun":       {},
 	"Shanghai":     {},
 	"Paris":        {},
@@ -30,7 +31,6 @@ var usableForks = map[string]struct{}{
 	"Istanbul":     {},
 	"MuirGlacier":  {},
 	"TestNetwork":  {},
-	//"Prague":       {}, TODO: enable once geth is updated to Prague
 }
 
 // NewTestCaseSplitter opens all JSON tests within path


### PR DESCRIPTION
## Description

This PR accepts prague fork in eth-test tool. This allows eth-tests to process Prague transactions. Whether Prague transaction can be processed correctly is out of the scope of this PR.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
