### PR TITLE
Missing Implementation of Transient Storage Operation in Stochastic R…

### DIFF
--- a/stochastic/operation.go
+++ b/stochastic/operation.go
@@ -30,6 +30,7 @@ const (
 	BeginSyncPeriodID
 	BeginTransactionID
 	CreateAccountID
+	CreateContractID
 	EmptyID
 	EndBlockID
 	EndSyncPeriodID
@@ -42,19 +43,19 @@ const (
 	GetCommittedStateID
 	GetNonceID
 	GetStateID
+	GetStorageRootID
+	GetTransientStateID
 	HasSelfDestructedID
 	RevertToSnapshotID
+	SelfDestructID
+	SelfDestruct6780ID
 	SetCodeID
 	SetNonceID
 	SetStateID
+	SetTransientStateID
 	SnapshotID
 	SubBalanceID
-	SelfDestructID
-	CreateContractID
-	GetStorageRootID
-	GetTransientStateID
-	SetTransientStateID
-	SelfDestruct6780ID
+
 	// Add new operations below this line
 
 	NumOps
@@ -92,9 +93,9 @@ var opText = map[int]string{
 	SetCodeID:           "SetCode",
 	SetNonceID:          "SetNonce",
 	SetStateID:          "SetState",
+	SetTransientStateID: "SetTransientState",
 	SnapshotID:          "Snapshot",
 	SubBalanceID:        "SubBalance",
-	SetTransientStateID: "SetTransientState",
 }
 
 // opMnemo is a mnemonics table for operations.
@@ -126,9 +127,9 @@ var opMnemo = map[int]string{
 	SetCodeID:           "SC",
 	SetNonceID:          "SO",
 	SetStateID:          "SS",
+	SetTransientStateID: "ST",
 	SnapshotID:          "SN",
 	SubBalanceID:        "SB",
-	SetTransientStateID: "ST",
 }
 
 // opNumArgs is an argument number table for operations.
@@ -160,9 +161,9 @@ var opNumArgs = map[int]int{
 	SetCodeID:           1,
 	SetNonceID:          1,
 	SetStateID:          3,
+	SetTransientStateID: 3,
 	SnapshotID:          0,
 	SubBalanceID:        1,
-	SetTransientStateID: 3,
 }
 
 // opId is an operation ID table.
@@ -193,10 +194,10 @@ var opId = map[string]int{
 	"S6": SelfDestruct6780ID,
 	"SC": SetCodeID,
 	"SO": SetNonceID,
-	"SN": SnapshotID,
-	"SB": SubBalanceID,
 	"SS": SetStateID,
 	"ST": SetTransientStateID,
+	"SN": SnapshotID,
+	"SB": SubBalanceID,
 }
 
 // argMnemo is the argument-class mnemonics table.

--- a/stochastic/replay.go
+++ b/stochastic/replay.go
@@ -408,6 +408,9 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 	case GetStorageRootID:
 		db.GetStorageRoot(addr)
 
+	case GetTransientStateID:
+		db.GetState(addr, key)
+
 	case HasSelfDestructedID:
 		db.HasSelfDestructed(addr)
 
@@ -425,6 +428,18 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 
 			// update active snapshots and perform a rollback in balance log
 			ss.snapshot = ss.snapshot[0:snapshotIdx]
+		}
+
+	case SelfDestructID:
+		db.SelfDestruct(addr)
+		if idx := find(ss.selfDestructed, addrIdx); idx == -1 {
+			ss.selfDestructed = append(ss.selfDestructed, addrIdx)
+		}
+
+	case SelfDestruct6780ID:
+		db.SelfDestruct6780(addr)
+		if idx := find(ss.selfDestructed, addrIdx); idx == -1 {
+			ss.selfDestructed = append(ss.selfDestructed, addrIdx)
 		}
 
 	case SetCodeID:
@@ -445,6 +460,9 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 
 	case SetStateID:
 		db.SetState(addr, key, value)
+
+	case SetTransientStateID:
+		db.SetTransientState(addr, key, value)
 
 	case SnapshotID:
 		id := db.Snapshot()
@@ -470,21 +488,8 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 			}
 			db.SubBalance(addr, uint256.NewInt(value), 0)
 		}
-
-	case SelfDestructID:
-		db.SelfDestruct(addr)
-		if idx := find(ss.selfDestructed, addrIdx); idx == -1 {
-			ss.selfDestructed = append(ss.selfDestructed, addrIdx)
-		}
-
-	case SelfDestruct6780ID:
-		db.SelfDestruct6780(addr)
-		if idx := find(ss.selfDestructed, addrIdx); idx == -1 {
-			ss.selfDestructed = append(ss.selfDestructed, addrIdx)
-		}
-
 	default:
-		ss.log.Fatal("invalid operation")
+		ss.log.Fatal("invalid operation "+opText[op])
 	}
 }
 


### PR DESCRIPTION
This PR adds the two missing operations `GetTransientState` and `SetTransientState` to the stochastic replayer. Without these two operations, the replayer crashes.

Recently, operations were added to ' operations. go '.  However, they were not sorted alphabetically. 
This PR sorts all maps related to StateDB operations as well.