### PR TITLE
Update Sonic dependency

### DIFF
--- a/rpc/evm.go
+++ b/rpc/evm.go
@@ -144,7 +144,12 @@ func (e *EvmExecutor) newEVM(msg *core.Message, hashErr *error) *vm.EVM {
 		Time:        e.timestamp,
 	}
 
-	vmConfig = opera.DefaultVMConfig
+	// The default rules only work until there are blocks that have been created
+	// using the single-proposer mode. The crucial difference in the VM setup is
+	// that in the single-proposer mode the charging of excess gas is disabled,
+	// while in the distributed-proposer mode (the default mode), it is enabled.
+	defaultVmConfig := opera.GetVmConfig(opera.Rules{})
+	vmConfig = defaultVmConfig
 	vmConfig.NoBaseFee = true
 	vmConfig.Interpreter = e.vmImpl
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -398,7 +398,7 @@ func NewTestConfig(t *testing.T, chainId ChainID, first, last uint64, validate b
 	if err != nil {
 		t.Fatalf("cannot get chain cfg: %v", err)
 	}
-	vmCfg := opera.DefaultVMConfig
+	vmCfg := opera.GetVmConfig(opera.Rules{}) // default VM config
 	vmCfg.NoBaseFee = true
 	vmCfg.Tracer = nil
 	vmCfg.Interpreter = nil
@@ -973,8 +973,22 @@ func (cc *configContext) setChainConfig() (err error) {
 
 func (cc *configContext) setVmConfig() (err error) {
 	if !IsEthereumNetwork(cc.cfg.ChainID) {
+		// The default VM config is sufficient for all Sonic blocks that have
+		// been created using the Multi-Proposer mode (aka. distributed block
+		// formation). With the switch to the Single-Proposer mode, the charging
+		// of excess gas is removed. This can be disabled by setting
+		//
+		// vmConfig.ChargeExcessGas = false
+		//
+		// or by passing rules with the corresponding feature being enabled to
+		// the opera.GetVmConfig function. However, right now, there seems to be
+		// no information about the network rules available in the substates,
+		// making this distinction impossible. This information may have to be
+		// tracked explicitly in the future.
+		defaultVmConfig := opera.GetVmConfig(opera.Rules{})
+
 		// SonicMainnetChainID, TestnetChainID, MainnetChainID:
-		cc.cfg.VmCfg = opera.DefaultVMConfig
+		cc.cfg.VmCfg = defaultVmConfig
 		cc.cfg.VmCfg.NoBaseFee = true
 	}
 


### PR DESCRIPTION
This PR updates the version of Sonic the main branch of Aida is depending on.

The main breaking change found during unit tests is the handling of the VM configuration. Right now, for all test sets the default VM configuration is sufficient. However, in the future, as the Sonic network may start using the single-proposer mode, the VM needs to be configured accordingly.