### PR TITLE
Go coverage include functions from other packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline {
                     }
                     steps {
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
-                             sh 'go test ./... -coverprofile=coverage.txt'
+                             sh 'go test ./... -coverprofile=coverage.txt -coverpkg=./...'
                              sh ('codecov upload-process -r 0xsoniclabs/aida -f ./coverage.txt -t ${CODECOV_TOKEN}')
                         }
                     }


### PR DESCRIPTION
## Description

This PR updates go coverage command to take accounts of all packages. For example, a test in `cmd` which cover lines in `utils` should be counted, but not counted by the current command. The new command disregards packages and reports coverage of the entire source code.