### PR TITLE
Add block timestamp to GetLogs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -23,3 +23,4 @@ ignore:
   - "**/*_mock.go"
   - "**/*_test.go"
   - "**/*.pb.go"
+  - "ethtest/mock_data.go"

--- a/cmd/aida-vm-adb/run_vm_adb_test.go
+++ b/cmd/aida-vm-adb/run_vm_adb_test.go
@@ -567,7 +567,9 @@ func TestVmAdb_ValidationFailsOnInvalidTransaction_Parallel(t *testing.T) {
 
 // emptyTx is a dummy substate that will be processed without crashing.
 var emptyTx = &substate.Substate{
-	Env: &substate.Env{},
+	Env: &substate.Env{
+		Timestamp: uint64(10),
+	},
 	Message: &substate.Message{
 		GasPrice: big.NewInt(12),
 		Value:    big.NewInt(1),

--- a/cmd/aida-vm-adb/run_vm_adb_test.go
+++ b/cmd/aida-vm-adb/run_vm_adb_test.go
@@ -74,7 +74,7 @@ func TestVmAdb_AllDbEventsAreIssuedInOrder_Sequential(t *testing.T) {
 		archiveBlockOne.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		archiveBlockOne.EXPECT().SubBalance(gomock.Any(), gomock.Any(), gomock.Any()),
 		archiveBlockOne.EXPECT().RevertToSnapshot(15),
-		archiveBlockOne.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		archiveBlockOne.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 		archiveBlockOne.EXPECT().EndTransaction(),
 		// Tx 2
 		archiveBlockOne.EXPECT().BeginTransaction(uint32(2)),
@@ -84,7 +84,7 @@ func TestVmAdb_AllDbEventsAreIssuedInOrder_Sequential(t *testing.T) {
 		archiveBlockOne.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		archiveBlockOne.EXPECT().SubBalance(gomock.Any(), gomock.Any(), gomock.Any()),
 		archiveBlockOne.EXPECT().RevertToSnapshot(16),
-		archiveBlockOne.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 2)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		archiveBlockOne.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 2)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 		archiveBlockOne.EXPECT().EndTransaction(),
 		archiveBlockOne.EXPECT().Release(),
 		// Block 3
@@ -96,7 +96,7 @@ func TestVmAdb_AllDbEventsAreIssuedInOrder_Sequential(t *testing.T) {
 		archiveBlockTwo.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		archiveBlockTwo.EXPECT().SubBalance(gomock.Any(), gomock.Any(), gomock.Any()),
 		archiveBlockTwo.EXPECT().RevertToSnapshot(17),
-		archiveBlockTwo.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 3, 1)), uint64(3), common.HexToHash(fmt.Sprintf("0x%016d", 3))),
+		archiveBlockTwo.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 3, 1)), uint64(3), common.HexToHash(fmt.Sprintf("0x%016d", 3)), uint64(10)),
 		archiveBlockTwo.EXPECT().EndTransaction(),
 		archiveBlockTwo.EXPECT().Release(),
 		// Block 4
@@ -161,7 +161,7 @@ func TestVmAdb_AllDbEventsAreIssuedInOrder_Parallel(t *testing.T) {
 		archiveBlockOne.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		archiveBlockOne.EXPECT().SubBalance(gomock.Any(), gomock.Any(), gomock.Any()),
 		archiveBlockOne.EXPECT().RevertToSnapshot(15),
-		archiveBlockOne.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		archiveBlockOne.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 		archiveBlockOne.EXPECT().EndTransaction(),
 		// Tx 2
 		archiveBlockOne.EXPECT().BeginTransaction(uint32(2)),
@@ -171,7 +171,7 @@ func TestVmAdb_AllDbEventsAreIssuedInOrder_Parallel(t *testing.T) {
 		archiveBlockOne.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		archiveBlockOne.EXPECT().SubBalance(gomock.Any(), gomock.Any(), gomock.Any()),
 		archiveBlockOne.EXPECT().RevertToSnapshot(19),
-		archiveBlockOne.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 2)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		archiveBlockOne.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 2)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 		archiveBlockOne.EXPECT().EndTransaction(),
 
 		archiveBlockOne.EXPECT().Release(),
@@ -186,7 +186,7 @@ func TestVmAdb_AllDbEventsAreIssuedInOrder_Parallel(t *testing.T) {
 		archiveBlockTwo.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		archiveBlockTwo.EXPECT().SubBalance(gomock.Any(), gomock.Any(), gomock.Any()),
 		archiveBlockTwo.EXPECT().RevertToSnapshot(17),
-		archiveBlockTwo.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 3, 1)), uint64(3), common.HexToHash(fmt.Sprintf("0x%016d", 3))),
+		archiveBlockTwo.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 3, 1)), uint64(3), common.HexToHash(fmt.Sprintf("0x%016d", 3)), uint64(10)),
 		archiveBlockTwo.EXPECT().EndTransaction(),
 		archiveBlockTwo.EXPECT().Release(),
 	)
@@ -404,7 +404,7 @@ func TestVmAdb_ValidationDoesNotFailOnValidTransaction_Sequential(t *testing.T) 
 		archive.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		archive.EXPECT().SubBalance(gomock.Any(), gomock.Any(), gomock.Any()),
 		archive.EXPECT().RevertToSnapshot(15),
-		archive.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		archive.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 		// end transaction is not called because we expect fail
 	)
 
@@ -458,7 +458,7 @@ func TestVmAdb_ValidationDoesNotFailOnValidTransaction_Parallel(t *testing.T) {
 		archive.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		archive.EXPECT().SubBalance(gomock.Any(), gomock.Any(), gomock.Any()),
 		archive.EXPECT().RevertToSnapshot(15),
-		archive.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		archive.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 	)
 
 	archive.EXPECT().GetCode(gomock.Any()).AnyTimes().Return([]byte{})
@@ -581,7 +581,8 @@ var emptyTx = &substate.Substate{
 var testTx = &substate.Substate{
 	InputSubstate: substate.WorldState{substatetypes.Address(testingAddress): substate.NewAccount(1, uint256.NewInt(1), []byte{})},
 	Env: &substate.Env{
-		GasLimit: 100_000_000,
+		GasLimit:  100_000_000,
+		Timestamp: uint64(10),
 	},
 	Message: &substate.Message{
 		GasPrice: big.NewInt(0),

--- a/cmd/aida-vm-sdb/run_eth_test.go
+++ b/cmd/aida-vm-sdb/run_eth_test.go
@@ -63,7 +63,7 @@ func TestVmSdb_Eth_AllDbEventsAreIssuedInOrder(t *testing.T) {
 		db.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		db.EXPECT().SubBalance(gomock.Any(), gomock.Any(), tracing.BalanceDecreaseGasBuy),
 		db.EXPECT().RevertToSnapshot(15),
-		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 0)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 0)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 		db.EXPECT().EndTransaction(),
 		db.EXPECT().EndBlock(),
 
@@ -76,7 +76,7 @@ func TestVmSdb_Eth_AllDbEventsAreIssuedInOrder(t *testing.T) {
 		db.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		db.EXPECT().SubBalance(gomock.Any(), gomock.Any(), tracing.BalanceDecreaseGasBuy),
 		db.EXPECT().RevertToSnapshot(15),
-		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 3, 1)), uint64(3), common.HexToHash(fmt.Sprintf("0x%016d", 3))),
+		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 3, 1)), uint64(3), common.HexToHash(fmt.Sprintf("0x%016d", 3)), uint64(10)),
 		db.EXPECT().EndTransaction(),
 		db.EXPECT().EndBlock(),
 	)
@@ -215,7 +215,7 @@ func TestVmSdb_Eth_ValidationDoesNotFailOnValidTransaction(t *testing.T) {
 		db.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		db.EXPECT().SubBalance(gomock.Any(), gomock.Any(), tracing.BalanceDecreaseGasBuy),
 		db.EXPECT().RevertToSnapshot(15),
-		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 		db.EXPECT().EndTransaction(),
 		db.EXPECT().EndBlock(),
 		db.EXPECT().GetHash(),

--- a/cmd/aida-vm-sdb/run_substate_test.go
+++ b/cmd/aida-vm-sdb/run_substate_test.go
@@ -70,7 +70,7 @@ func TestVmSdb_Substate_AllDbEventsAreIssuedInOrder(t *testing.T) {
 		db.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		db.EXPECT().SubBalance(gomock.Any(), gomock.Any(), tracing.BalanceDecreaseGasBuy),
 		db.EXPECT().RevertToSnapshot(15),
-		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 		db.EXPECT().EndTransaction(),
 		// Tx 2
 		db.EXPECT().PrepareSubstate(gomock.Any(), uint64(2)),
@@ -81,7 +81,7 @@ func TestVmSdb_Substate_AllDbEventsAreIssuedInOrder(t *testing.T) {
 		db.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		db.EXPECT().SubBalance(gomock.Any(), gomock.Any(), tracing.BalanceDecreaseGasBuy),
 		db.EXPECT().RevertToSnapshot(17),
-		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 2)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 2)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 		db.EXPECT().EndTransaction(),
 		db.EXPECT().EndBlock(),
 		// Block 3
@@ -94,7 +94,7 @@ func TestVmSdb_Substate_AllDbEventsAreIssuedInOrder(t *testing.T) {
 		db.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		db.EXPECT().SubBalance(gomock.Any(), gomock.Any(), tracing.BalanceDecreaseGasBuy),
 		db.EXPECT().RevertToSnapshot(19),
-		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 3, 1)), uint64(3), common.HexToHash(fmt.Sprintf("0x%016d", 3))),
+		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 3, 1)), uint64(3), common.HexToHash(fmt.Sprintf("0x%016d", 3)), uint64(10)),
 		db.EXPECT().EndTransaction(),
 		db.EXPECT().EndBlock(),
 		// Pseudo transaction do not use snapshots.
@@ -242,7 +242,7 @@ func TestVmSdb_Substate_ValidationDoesNotFailOnValidTransaction(t *testing.T) {
 		db.EXPECT().AddBalance(testSender, gomock.Any(), tracing.BalanceIncreaseGasReturn),
 
 		// Post-transaction operations
-		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 		db.EXPECT().EndTransaction(),
 		db.EXPECT().EndBlock(),
 	)
@@ -288,7 +288,7 @@ func TestVmSdb_Substate_ValidationFailsOnInvalidTransaction(t *testing.T) {
 		db.EXPECT().GetCode(testSender).Return(nil),
 		db.EXPECT().GetBalance(testSender).Return(uint256.NewInt(0)), // < this is not enough for the gas
 		db.EXPECT().RevertToSnapshot(15),
-		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 		// EndTransaction does not get called because validation fails
 	)
 
@@ -329,7 +329,8 @@ var emptyTx = &substate.Substate{
 // testTx is a dummy substate used for testing validation.
 var testTx = &substate.Substate{
 	Env: &substate.Env{
-		GasLimit: 100_000_000,
+		GasLimit:  100_000_000,
+		Timestamp: uint64(10),
 	},
 	Message: &substate.Message{
 		From:      substatetypes.Address{0x01},

--- a/cmd/aida-vm-sdb/run_substate_test.go
+++ b/cmd/aida-vm-sdb/run_substate_test.go
@@ -313,7 +313,8 @@ func TestVmSdb_Substate_ValidationFailsOnInvalidTransaction(t *testing.T) {
 // emptyTx is a dummy substate that will be processed without crashing.
 var emptyTx = &substate.Substate{
 	Env: &substate.Env{
-		GasLimit: 100_000_000,
+		GasLimit:  100_000_000,
+		Timestamp: uint64(10),
 	},
 	Message: &substate.Message{
 		GasPrice:  big.NewInt(12),

--- a/cmd/aida-vm/run_vm_test.go
+++ b/cmd/aida-vm/run_vm_test.go
@@ -71,7 +71,7 @@ func TestVm_AllDbEventsAreIssuedInOrder_Sequential(t *testing.T) {
 		db.EXPECT().GetCode(gomock.Any()).Return(nil),
 		db.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		db.EXPECT().RevertToSnapshot(15),
-		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 		db.EXPECT().EndTransaction(),
 		// Tx 2
 		db.EXPECT().BeginTransaction(uint32(2)),
@@ -80,7 +80,7 @@ func TestVm_AllDbEventsAreIssuedInOrder_Sequential(t *testing.T) {
 		db.EXPECT().GetCode(gomock.Any()).Return(nil),
 		db.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		db.EXPECT().RevertToSnapshot(17),
-		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 2)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 2)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 		db.EXPECT().EndTransaction(),
 		// Block 3
 		db.EXPECT().BeginTransaction(uint32(1)),
@@ -89,7 +89,7 @@ func TestVm_AllDbEventsAreIssuedInOrder_Sequential(t *testing.T) {
 		db.EXPECT().GetCode(gomock.Any()).Return(nil),
 		db.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		db.EXPECT().RevertToSnapshot(19),
-		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 3, 1)), uint64(3), common.HexToHash(fmt.Sprintf("0x%016d", 3))),
+		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 3, 1)), uint64(3), common.HexToHash(fmt.Sprintf("0x%016d", 3)), uint64(10)),
 		db.EXPECT().EndTransaction(),
 		// Pseudo Tx
 		db.EXPECT().BeginTransaction(uint32(utils.PseudoTx)),
@@ -260,7 +260,7 @@ func TestVmAdb_ValidationDoesNotFailOnValidTransaction_Sequential(t *testing.T) 
 		db.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		db.EXPECT().SubBalance(gomock.Any(), gomock.Any(), tracing.BalanceDecreaseGasBuy),
 		db.EXPECT().RevertToSnapshot(15),
-		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 	)
 
 	// Code may be fetched at any time.
@@ -312,7 +312,7 @@ func TestVmAdb_ValidationDoesNotFailOnValidTransaction_Parallel(t *testing.T) {
 		db.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1000)),
 		db.EXPECT().SubBalance(gomock.Any(), gomock.Any(), tracing.BalanceDecreaseGasBuy),
 		db.EXPECT().RevertToSnapshot(15),
-		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2))),
+		db.EXPECT().GetLogs(common.HexToHash(fmt.Sprintf("0x%016d%016d", 2, 1)), uint64(2), common.HexToHash(fmt.Sprintf("0x%016d", 2)), uint64(10)),
 	)
 
 	db.EXPECT().GetCode(gomock.Any()).AnyTimes().Return([]byte{})
@@ -416,7 +416,9 @@ func TestVm_ValidationFailsOnInvalidTransaction_Parallel(t *testing.T) {
 
 // emptyTx is a dummy substate that will be processed without crashing.
 var emptyTx = &substate.Substate{
-	Env: &substate.Env{},
+	Env: &substate.Env{
+		Timestamp: uint64(10),
+	},
 	Message: &substate.Message{
 		Gas:      10000,
 		GasPrice: big.NewInt(0),

--- a/cmd/aida-vm/run_vm_test.go
+++ b/cmd/aida-vm/run_vm_test.go
@@ -432,7 +432,9 @@ var emptyTx = &substate.Substate{
 // testTx is a dummy substate used for testing validation.
 var testTx = &substate.Substate{
 	InputSubstate: substate.WorldState{substatetypes.Address(testingAddress): substate.NewAccount(1, uint256.NewInt(1), []byte{})},
-	Env:           &substate.Env{},
+	Env: &substate.Env{
+		Timestamp: uint64(10),
+	},
 	Message: &substate.Message{
 		GasPrice: big.NewInt(12),
 		Value:    big.NewInt(1),

--- a/ethtest/mock_data.go
+++ b/ethtest/mock_data.go
@@ -50,7 +50,7 @@ func CreateTestTransaction(t *testing.T) txcontext.TxContext {
 			Difficulty: newBigInt(1),
 			GasLimit:   newBigInt(1),
 			Number:     newBigInt(1),
-			Timestamp:  newBigInt(1),
+			Timestamp:  newBigInt(10),
 			BaseFee:    newBigInt(1),
 			chainCfg:   chainCfg,
 			fork:       "Cancun",

--- a/executor/extension/profiler/operation_profiler_test.go
+++ b/executor/extension/profiler/operation_profiler_test.go
@@ -300,6 +300,7 @@ func TestOperationProfiler_WithMalformedConfig(t *testing.T) {
 func getStateDbFuncs(db state.StateDB) []func() {
 	mockAddress := common.HexToAddress("0x00000F1")
 	mockHash := common.BigToHash(big.NewInt(0))
+	mockTimestamp := uint64(0)
 	return []func(){
 		func() { db.CreateAccount(mockAddress) },
 		func() { db.CreateContract(mockAddress) },
@@ -349,7 +350,7 @@ func getStateDbFuncs(db state.StateDB) []func() {
 		func() { db.BeginSyncPeriod(0) },
 		func() { db.EndSyncPeriod() },
 		func() { db.AddLog(nil) },
-		func() { db.GetLogs(mockHash, uint64(0), mockHash) },
+		func() { db.GetLogs(mockHash, uint64(0), mockHash, mockTimestamp) },
 		func() { db.PointCache() },
 		func() { db.Witness() },
 		func() { db.AddPreimage(mockHash, []byte{0}) },
@@ -403,7 +404,7 @@ func prepareMockStateDb(m *state.MockStateDB) {
 	m.EXPECT().BeginSyncPeriod(gomock.Any()).AnyTimes()
 	m.EXPECT().EndSyncPeriod().AnyTimes()
 	m.EXPECT().AddLog(gomock.Any()).AnyTimes()
-	m.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	m.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	m.EXPECT().PointCache().AnyTimes()
 	m.EXPECT().Witness().AnyTimes()
 	m.EXPECT().AddPreimage(gomock.Any(), gomock.Any()).AnyTimes()
@@ -456,7 +457,7 @@ func prepareMockStateDbOnce(m *state.MockStateDB) {
 	m.EXPECT().BeginSyncPeriod(gomock.Any())
 	m.EXPECT().EndSyncPeriod()
 	m.EXPECT().AddLog(gomock.Any())
-	m.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any())
+	m.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	m.EXPECT().PointCache()
 	m.EXPECT().Witness()
 	m.EXPECT().AddPreimage(gomock.Any(), gomock.Any())

--- a/executor/extension/statedb/archive_inquirer_test.go
+++ b/executor/extension/statedb/archive_inquirer_test.go
@@ -125,7 +125,7 @@ func TestArchiveInquirer_RunsRandomTransactionsInBackground(t *testing.T) {
 	archive.EXPECT().SetCode(gomock.Any(), gomock.Any()).AnyTimes()
 	archive.EXPECT().GetRefund().AnyTimes()
 	archive.EXPECT().RevertToSnapshot(gomock.Any()).AnyTimes()
-	archive.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	archive.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	archive.EXPECT().EndTransaction().AnyTimes()
 	archive.EXPECT().Release().MinTimes(1)
 	archive.EXPECT().GetStorageRoot(gomock.Any()).AnyTimes()

--- a/executor/transaction_processor.go
+++ b/executor/transaction_processor.go
@@ -358,7 +358,7 @@ func (s *aidaProcessor) processRegularTx(db state.VmStateDB, block int, tx int, 
 
 	blockHash := common.HexToHash(fmt.Sprintf("0x%016d", block))
 	// if no prior error, create result and pass it to the data.
-	res = newTransactionResult(db.GetLogs(txHash, uint64(block), blockHash), msg, msgResult, finalError, msg.From)
+	res = newTransactionResult(db.GetLogs(txHash, uint64(block), blockHash, inputEnv.GetTimestamp()), msg, msgResult, finalError, msg.From)
 	return
 }
 
@@ -644,7 +644,7 @@ func (a *toscaTxContext) EmitLog(log tosca.Log) {
 
 func (a *toscaTxContext) GetLogs() []tosca.Log {
 	res := []tosca.Log{}
-	for _, l := range a.db.GetLogs(common.Hash{}, 0, common.Hash{}) {
+	for _, l := range a.db.GetLogs(common.Hash{}, 0, common.Hash{}, 0) {
 		topics := make([]tosca.Hash, len(l.Topics))
 		for i, t := range l.Topics {
 			topics[i] = tosca.Hash(t)

--- a/state/carmen.go
+++ b/state/carmen.go
@@ -345,7 +345,7 @@ func (s *carmenStateDB) AddLog(log *types.Log) {
 	})
 }
 
-func (s *carmenStateDB) GetLogs(common.Hash, uint64, common.Hash) []*types.Log {
+func (s *carmenStateDB) GetLogs(common.Hash, uint64, common.Hash, uint64) []*types.Log {
 	list := s.txCtx.GetLogs()
 
 	res := make([]*types.Log, 0, len(list))

--- a/state/geth.go
+++ b/state/geth.go
@@ -356,7 +356,7 @@ func (s *gethStateDB) AccessEvents() *geth.AccessEvents {
 
 func (s *gethStateDB) GetLogs(hash common.Hash, block uint64, blockHash common.Hash, blkTimestamp uint64) []*types.Log {
 	if db, ok := s.db.(*geth.StateDB); ok {
-		return db.GetLogs(hash, block, blockHash, blkTimestamp) // TODO: pass block timestamp
+		return db.GetLogs(hash, block, blockHash, blkTimestamp)
 	}
 	return []*types.Log{}
 }

--- a/state/geth.go
+++ b/state/geth.go
@@ -354,9 +354,9 @@ func (s *gethStateDB) AccessEvents() *geth.AccessEvents {
 	return s.accessEvents
 }
 
-func (s *gethStateDB) GetLogs(hash common.Hash, block uint64, blockHash common.Hash) []*types.Log {
+func (s *gethStateDB) GetLogs(hash common.Hash, block uint64, blockHash common.Hash, blkTimestamp uint64) []*types.Log {
 	if db, ok := s.db.(*geth.StateDB); ok {
-		return db.GetLogs(hash, block, blockHash, 0) // TODO: pass block timestamp
+		return db.GetLogs(hash, block, blockHash, blkTimestamp) // TODO: pass block timestamp
 	}
 	return []*types.Log{}
 }

--- a/state/memory.go
+++ b/state/memory.go
@@ -420,7 +420,7 @@ func collectLogs(s *snapshot) []*types.Log {
 	return logs
 }
 
-func (db *inMemoryStateDB) GetLogs(txHash common.Hash, block uint64, blockHash common.Hash) []*types.Log {
+func (db *inMemoryStateDB) GetLogs(txHash common.Hash, block uint64, blockHash common.Hash, blkTimestamp uint64) []*types.Log {
 	// Since the in-memory stateDB is only to be used for a single
 	// transaction, all logs are from the same transactions. But
 	// those need to be collected in the right order (inverse order

--- a/state/proxy/deletion.go
+++ b/state/proxy/deletion.go
@@ -229,8 +229,8 @@ func (r *DeletionProxy) AddLog(log *types.Log) {
 }
 
 // GetLogs retrieves log entries.
-func (r *DeletionProxy) GetLogs(hash common.Hash, block uint64, blockHash common.Hash) []*types.Log {
-	return r.db.GetLogs(hash, block, blockHash)
+func (r *DeletionProxy) GetLogs(hash common.Hash, block uint64, blockHash common.Hash, blkTimestamp uint64) []*types.Log {
+	return r.db.GetLogs(hash, block, blockHash, blkTimestamp)
 }
 
 // PointCache returns the point cache used in computations.

--- a/state/proxy/logger.go
+++ b/state/proxy/logger.go
@@ -303,9 +303,9 @@ func (s *loggingVmStateDb) AddLog(entry *types.Log) {
 	s.db.AddLog(entry)
 }
 
-func (s *loggingVmStateDb) GetLogs(hash common.Hash, block uint64, blockHash common.Hash) []*types.Log {
-	res := s.db.GetLogs(hash, block, blockHash)
-	s.writeLog("GetLogs, %v, %v, %v, %v", hash, block, blockHash, res)
+func (s *loggingVmStateDb) GetLogs(hash common.Hash, block uint64, blockHash common.Hash, blkTimestamp uint64) []*types.Log {
+	res := s.db.GetLogs(hash, block, blockHash, blkTimestamp)
+	s.writeLog("GetLogs, %v, %v, %v, %v, %v", hash, block, blockHash, blkTimestamp, res)
 	return res
 }
 

--- a/state/proxy/profiler.go
+++ b/state/proxy/profiler.go
@@ -373,10 +373,10 @@ func (p *ProfilerProxy) AddLog(log *types.Log) {
 }
 
 // GetLogs retrieves log entries.
-func (p *ProfilerProxy) GetLogs(hash common.Hash, block uint64, blockHash common.Hash) []*types.Log {
+func (p *ProfilerProxy) GetLogs(hash common.Hash, block uint64, blockHash common.Hash, blkTimestamp uint64) []*types.Log {
 	var logs []*types.Log
 	p.do(operation.GetLogsID, func() {
-		logs = p.db.GetLogs(hash, block, blockHash)
+		logs = p.db.GetLogs(hash, block, blockHash, blkTimestamp)
 	})
 	return logs
 }

--- a/state/proxy/recorder.go
+++ b/state/proxy/recorder.go
@@ -319,8 +319,8 @@ func (r *RecorderProxy) AddLog(log *types.Log) {
 }
 
 // GetLogs retrieves log entries.
-func (r *RecorderProxy) GetLogs(hash common.Hash, block uint64, blockHash common.Hash) []*types.Log {
-	return r.db.GetLogs(hash, block, blockHash)
+func (r *RecorderProxy) GetLogs(hash common.Hash, block uint64, blockHash common.Hash, blkTimestamp uint64) []*types.Log {
+	return r.db.GetLogs(hash, block, blockHash, blkTimestamp)
 }
 
 // PointCache returns the point cache used in computations.

--- a/state/proxy/shadow.go
+++ b/state/proxy/shadow.go
@@ -314,9 +314,9 @@ func (s *shadowVmStateDb) AddLog(log *types.Log) {
 	})
 }
 
-func (s *shadowVmStateDb) GetLogs(hash common.Hash, block uint64, blockHash common.Hash) []*types.Log {
-	logsP := s.prime.GetLogs(hash, block, blockHash)
-	logsS := s.shadow.GetLogs(hash, block, blockHash)
+func (s *shadowVmStateDb) GetLogs(hash common.Hash, block uint64, blockHash common.Hash, blkTimestamp uint64) []*types.Log {
+	logsP := s.prime.GetLogs(hash, block, blockHash, blkTimestamp)
+	logsS := s.shadow.GetLogs(hash, block, blockHash, blkTimestamp)
 
 	equal := len(logsP) == len(logsS)
 	if equal {
@@ -328,8 +328,8 @@ func (s *shadowVmStateDb) GetLogs(hash common.Hash, block uint64, blockHash comm
 		}
 	}
 	if !equal {
-		s.logIssue("GetLogs", logsP, logsS, hash, blockHash)
-		s.err = fmt.Errorf("%v diverged from shadow DB", getOpcodeString("GetLogs", hash, blockHash))
+		s.logIssue("GetLogs", logsP, logsS, hash, blockHash, blkTimestamp)
+		s.err = fmt.Errorf("%v diverged from shadow DB", getOpcodeString("GetLogs", hash, blockHash, blkTimestamp))
 	}
 	return logsP
 }

--- a/state/proxy/shadow_test.go
+++ b/state/proxy/shadow_test.go
@@ -745,11 +745,12 @@ func TestShadowState_GetLogs_Success(t *testing.T) {
 	blockHash := common.HexToHash("0x2")
 	log1 := &types.Log{}
 	block := uint64(0)
+	blkTimestamp := uint64(10)
 
-	pdb.EXPECT().GetLogs(txHash, block, blockHash).Return([]*types.Log{log1})
-	sdb.EXPECT().GetLogs(txHash, block, blockHash).Return([]*types.Log{log1})
+	pdb.EXPECT().GetLogs(txHash, block, blockHash, blkTimestamp).Return([]*types.Log{log1})
+	sdb.EXPECT().GetLogs(txHash, block, blockHash, blkTimestamp).Return([]*types.Log{log1})
 
-	db.GetLogs(txHash, block, blockHash)
+	db.GetLogs(txHash, block, blockHash, blkTimestamp)
 	if err := db.Error(); err != nil {
 		t.Fatalf("Failed to compare logs; %v", err)
 	}
@@ -764,11 +765,12 @@ func TestShadowState_GetLogsExpectError_LengthDifferent(t *testing.T) {
 	blockHash := common.HexToHash("0x2")
 	log1 := &types.Log{}
 	block := uint64(0)
+	blkTimestamp := uint64(10)
 
-	pdb.EXPECT().GetLogs(txHash, block, blockHash).Return(nil)
-	sdb.EXPECT().GetLogs(txHash, block, blockHash).Return([]*types.Log{log1})
+	pdb.EXPECT().GetLogs(txHash, block, blockHash, blkTimestamp).Return(nil)
+	sdb.EXPECT().GetLogs(txHash, block, blockHash, blkTimestamp).Return([]*types.Log{log1})
 
-	db.GetLogs(txHash, block, blockHash)
+	db.GetLogs(txHash, block, blockHash, blkTimestamp)
 	if err := db.Error(); err == nil {
 		t.Fatal("Expect mismatched GetLogs lengths")
 	}
@@ -784,11 +786,12 @@ func TestShadowState_GetLogsExpectError_BloomDifferent(t *testing.T) {
 	log1 := &types.Log{}
 	log2 := &types.Log{Address: common.HexToAddress("0x3")}
 	block := uint64(0)
+	blkTimestamp := uint64(10)
 
-	pdb.EXPECT().GetLogs(txHash, block, blockHash).Return([]*types.Log{log1})
-	sdb.EXPECT().GetLogs(txHash, block, blockHash).Return([]*types.Log{log2})
+	pdb.EXPECT().GetLogs(txHash, block, blockHash, blkTimestamp).Return([]*types.Log{log1})
+	sdb.EXPECT().GetLogs(txHash, block, blockHash, blkTimestamp).Return([]*types.Log{log2})
 
-	db.GetLogs(txHash, block, blockHash)
+	db.GetLogs(txHash, block, blockHash, blkTimestamp)
 	if err := db.Error(); err == nil {
 		t.Fatal("Expect mismatched log values")
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -83,7 +83,7 @@ type VmStateDB interface {
 
 	// Logging
 	AddLog(*types.Log)
-	GetLogs(common.Hash, uint64, common.Hash) []*types.Log
+	GetLogs(common.Hash, uint64, common.Hash, uint64) []*types.Log
 
 	// PointCache returns the point cache used in computations
 	PointCache() *utils.PointCache

--- a/state/state_mock.go
+++ b/state/state_mock.go
@@ -313,17 +313,17 @@ func (mr *MockVmStateDBMockRecorder) GetCommittedState(arg0, arg1 any) *gomock.C
 }
 
 // GetLogs mocks base method.
-func (m *MockVmStateDB) GetLogs(arg0 common.Hash, arg1 uint64, arg2 common.Hash) []*types.Log {
+func (m *MockVmStateDB) GetLogs(arg0 common.Hash, arg1 uint64, arg2 common.Hash, arg3 uint64) []*types.Log {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLogs", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetLogs", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*types.Log)
 	return ret0
 }
 
 // GetLogs indicates an expected call of GetLogs.
-func (mr *MockVmStateDBMockRecorder) GetLogs(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockVmStateDBMockRecorder) GetLogs(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockVmStateDB)(nil).GetLogs), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockVmStateDB)(nil).GetLogs), arg0, arg1, arg2, arg3)
 }
 
 // GetNonce mocks base method.
@@ -928,17 +928,17 @@ func (mr *MockNonCommittableStateDBMockRecorder) GetHash() *gomock.Call {
 }
 
 // GetLogs mocks base method.
-func (m *MockNonCommittableStateDB) GetLogs(arg0 common.Hash, arg1 uint64, arg2 common.Hash) []*types.Log {
+func (m *MockNonCommittableStateDB) GetLogs(arg0 common.Hash, arg1 uint64, arg2 common.Hash, arg3 uint64) []*types.Log {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLogs", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetLogs", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*types.Log)
 	return ret0
 }
 
 // GetLogs indicates an expected call of GetLogs.
-func (mr *MockNonCommittableStateDBMockRecorder) GetLogs(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockNonCommittableStateDBMockRecorder) GetLogs(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockNonCommittableStateDB)(nil).GetLogs), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockNonCommittableStateDB)(nil).GetLogs), arg0, arg1, arg2, arg3)
 }
 
 // GetNonce mocks base method.
@@ -1683,17 +1683,17 @@ func (mr *MockStateDBMockRecorder) GetHash() *gomock.Call {
 }
 
 // GetLogs mocks base method.
-func (m *MockStateDB) GetLogs(arg0 common.Hash, arg1 uint64, arg2 common.Hash) []*types.Log {
+func (m *MockStateDB) GetLogs(arg0 common.Hash, arg1 uint64, arg2 common.Hash, arg3 uint64) []*types.Log {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLogs", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetLogs", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*types.Log)
 	return ret0
 }
 
 // GetLogs indicates an expected call of GetLogs.
-func (mr *MockStateDBMockRecorder) GetLogs(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockStateDBMockRecorder) GetLogs(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockStateDB)(nil).GetLogs), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockStateDB)(nil).GetLogs), arg0, arg1, arg2, arg3)
 }
 
 // GetMemoryUsage mocks base method.

--- a/stochastic/event_proxy.go
+++ b/stochastic/event_proxy.go
@@ -300,9 +300,9 @@ func (p *EventProxy) AddLog(log *types.Log) {
 }
 
 // GetLogs retrieves log entries.
-func (p *EventProxy) GetLogs(hash common.Hash, block uint64, blockHash common.Hash) []*types.Log {
+func (p *EventProxy) GetLogs(hash common.Hash, block uint64, blockHash common.Hash, blkTimestamp uint64) []*types.Log {
 	// call real StateDB
-	return p.db.GetLogs(hash, block, blockHash)
+	return p.db.GetLogs(hash, block, blockHash, blkTimestamp)
 }
 
 // PointCache returns the point cache used in computations.

--- a/tracer/operation/operation_test.go
+++ b/tracer/operation/operation_test.go
@@ -285,8 +285,8 @@ func (s *MockStateDB) ForEachStorage(addr common.Address, cb func(common.Hash, c
 	return nil
 }
 
-func (s *MockStateDB) GetLogs(hash common.Hash, block uint64, blockHash common.Hash) []*types.Log {
-	s.recording = append(s.recording, Record{GetLogsID, []any{hash, block, blockHash}})
+func (s *MockStateDB) GetLogs(hash common.Hash, block uint64, blockHash common.Hash, blkTimestamp uint64) []*types.Log {
+	s.recording = append(s.recording, Record{GetLogsID, []any{hash, block, blockHash, blkTimestamp}})
 	return nil
 }
 


### PR DESCRIPTION
## Description

This PR adds `blkTimestamp` to `StateDB.GetLogs()` interface to suit newest `go-ethereum` version

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

