### PR TITLE
Call SetTransientStorage; Add substate-encoding flag

### DIFF
--- a/cmd/aida-sdb/record.go
+++ b/cmd/aida-sdb/record.go
@@ -111,7 +111,6 @@ func record(
 		executor.Params{
 			From:                   int(cfg.First),
 			To:                     int(cfg.Last) + 1,
-			NumWorkers:             cfg.Workers,
 			ParallelismGranularity: executor.TransactionLevel,
 		},
 		processor,

--- a/cmd/aida-sdb/record.go
+++ b/cmd/aida-sdb/record.go
@@ -39,6 +39,8 @@ var RecordCommand = cli.Command{
 	ArgsUsage: "<blockNumFirst> <blockNumLast>",
 	Flags: []cli.Flag{
 		&utils.UpdateBufferSizeFlag,
+		&utils.SubstateEncodingFlag,
+		&utils.DbTmpFlag,
 		&utils.CpuProfileFlag,
 		&utils.SyncPeriodLengthFlag,
 		&utils.WorkersFlag,
@@ -109,6 +111,7 @@ func record(
 		executor.Params{
 			From:                   int(cfg.First),
 			To:                     int(cfg.Last) + 1,
+			NumWorkers:             cfg.Workers,
 			ParallelismGranularity: executor.TransactionLevel,
 		},
 		processor,

--- a/state/proxy/proxy_test.go
+++ b/state/proxy/proxy_test.go
@@ -46,6 +46,8 @@ func TestProxies_GetLogs(t *testing.T) {
 	proxies := getAllProxyImpls(t, base)
 	addr := common.Address{0x11}
 	hash := common.Hash{0x12}
+	key := common.Hash{0x13}
+	val := common.Hash{0x14}
 	blk := uint64(2)
 	blkHash := common.Hash{2}
 	blkTimestamp := uint64(13)
@@ -73,6 +75,12 @@ func TestProxies_GetLogs(t *testing.T) {
 	for name, proxy := range proxies {
 		t.Run(name+"_GetLogs", func(t *testing.T) {
 			proxy.GetLogs(hash, blk, blkHash, blkTimestamp)
+		})
+	}
+	base.EXPECT().SetTransientState(addr, key, val).Times(len(proxies) + 1)
+	for name, proxy := range proxies {
+		t.Run(name+"_SetTransientState", func(t *testing.T) {
+			proxy.SetTransientState(addr, key, val)
 		})
 	}
 }

--- a/state/proxy/recorder.go
+++ b/state/proxy/recorder.go
@@ -209,7 +209,7 @@ func (r *RecorderProxy) SetTransientState(addr common.Address, key common.Hash, 
 	} else {
 		r.write(operation.NewSetTransientState(contract, key, value))
 	}
-	r.db.SetState(addr, key, value)
+	r.db.SetTransientState(addr, key, value)
 }
 
 func (r *RecorderProxy) GetTransientState(addr common.Address, key common.Hash) common.Hash {


### PR DESCRIPTION
## Description

This PR fixes `aida-sdb record` by 
1) Fixing`recordProxy` calling correct func in `SetTransientState`
2) Adding `SubstateEncodingFlag` to the cmd

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
