### PR TITLE
Fix eth-test incorrect cfg init

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,6 +168,7 @@ pipeline {
                                 --vm-impl geth \
                                 --db-impl geth \
                                 ${TMPDB} \
+                                --chainid 1337 \
                                 --fork Cancun \
                                 ${env.WORKSPACE}/eth-test-package/GeneralStateTests/stTransactionTest"""
                         }

--- a/cmd/aida-vm-sdb/run_eth.go
+++ b/cmd/aida-vm-sdb/run_eth.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/0xsoniclabs/aida/executor"
 	"github.com/0xsoniclabs/aida/executor/extension/logger"
 	"github.com/0xsoniclabs/aida/executor/extension/primer"
@@ -93,6 +94,9 @@ func RunEthereumTest(ctx *cli.Context) error {
 	processor, err := executor.MakeEthTestProcessor(cfg)
 	if err != nil {
 		return err
+	}
+	if !ctx.IsSet(utils.ChainIDFlag.Name) {
+		return fmt.Errorf("please specify chain ID using --%s flag (1337 for most cases for this tool)", utils.ChainIDFlag.Name)
 	}
 
 	return runEth(cfg, executor.NewEthStateTestProvider(cfg), nil, processor, nil)

--- a/cmd/aida-vm-sdb/run_eth.go
+++ b/cmd/aida-vm-sdb/run_eth.go
@@ -89,7 +89,6 @@ func RunEthereumTest(ctx *cli.Context) error {
 
 	cfg.StateValidationMode = utils.SubsetCheck
 	cfg.ValidateTxState = true
-	cfg.ChainID = utils.EthTestsChainID
 
 	processor, err := executor.MakeEthTestProcessor(cfg)
 	if err != nil {

--- a/cmd/aida-vm-sdb/run_eth_test.go
+++ b/cmd/aida-vm-sdb/run_eth_test.go
@@ -18,7 +18,10 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 	"strings"
 	"testing"
 
@@ -286,4 +289,17 @@ func TestVmSdb_Eth_ValidationDoesFailOnInvalidTransaction(t *testing.T) {
 	if !strings.Contains(err.Error(), "pre alloc validation failed") {
 		t.Fatalf("unexpected error\ngot: %v\n want: %v", err, "pre alloc validation failed")
 	}
+}
+
+func TestVmSdb_EthTest_FailsWhenChainIDIsNotSet(t *testing.T) {
+	flagSet := flag.NewFlagSet("utils_config_test", 0)
+	flagSet.Int(utils.ChainIDFlag.Name, int(utils.SonicMainnetChainID), "Chain ID.")
+	err := flagSet.Parse([]string{t.TempDir()})
+	require.NoError(t, err)
+
+	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
+	ctx.Command = &cli.Command{Name: "test_command"}
+
+	err = RunEthereumTest(ctx)
+	require.ErrorContains(t, err, fmt.Sprintf("please specify chain ID using --%s flag (1337 for most cases for this tool)", utils.ChainIDFlag.Name))
 }

--- a/ethtest/mock_data_utils.go
+++ b/ethtest/mock_data_utils.go
@@ -200,3 +200,10 @@ func CreateTransactionThatFailsSenderValidation(t *testing.T) txcontext.TxContex
 		env:     &stBlockEnvironment{fork: "Shanghai"}, // FORK MUST BE Shanghai
 	}
 }
+
+func CreateTestTransactionWithUnknownFork(*testing.T) txcontext.TxContext {
+	return &StateTestContext{
+		env:  &stBlockEnvironment{fork: "unknown"},
+		fork: "unknown",
+	}
+}

--- a/executor/extension/statedb/eth_state_test_db_prepper.go
+++ b/executor/extension/statedb/eth_state_test_db_prepper.go
@@ -47,7 +47,7 @@ type ethStateTestDbPrepper struct {
 	log logger.Logger
 }
 
-func (e ethStateTestDbPrepper) PreBlock(_ executor.State[txcontext.TxContext], ctx *executor.Context) error {
+func (e ethStateTestDbPrepper) PreBlock(s executor.State[txcontext.TxContext], ctx *executor.Context) error {
 	var err error
 	cfg := e.cfg
 	// We reduce the node cache size to be used by Carmen to 1 MB
@@ -55,6 +55,11 @@ func (e ethStateTestDbPrepper) PreBlock(_ executor.State[txcontext.TxContext], c
 	// the processing time of each transaction.
 	cfg.CarmenStateCacheSize = 1000
 	cfg.CarmenNodeCacheSize = (16 << 20) // = 16 MiB
+	// Init the chain config with current tests fork
+	cfg.ChainCfg, err = cfg.GetChainConfig(s.Data.GetBlockEnvironment().GetFork())
+	if err != nil {
+		return fmt.Errorf("cannot init chain config: %w", err)
+	}
 	ctx.State, ctx.StateDbPath, err = utils.PrepareStateDB(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statedb; %v", err)

--- a/executor/extension/statedb/eth_state_test_db_prepper_test.go
+++ b/executor/extension/statedb/eth_state_test_db_prepper_test.go
@@ -17,6 +17,7 @@
 package statedb
 
 import (
+	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 
@@ -78,4 +79,16 @@ func Test_ethStateTestDbPrepper_PostBlockCleansTmpDir(t *testing.T) {
 	if _, err := os.Stat(dirPath); !os.IsNotExist(err) {
 		t.Fatalf("tmp dir not removed")
 	}
+}
+
+func Test_ethStateTestDbPrepper_PreBlock_FailsWithUnknownFork(t *testing.T) {
+	cfg := &utils.Config{
+		ChainID:  utils.EthTestsChainID,
+		LogLevel: "critical",
+	}
+	ext := ethStateTestDbPrepper{cfg: cfg, log: logger.NewLogger(cfg.LogLevel, "EthStatePrepper")}
+	testData := ethtest.CreateTestTransactionWithUnknownFork(t)
+
+	err := ext.PreBlock(executor.State[txcontext.TxContext]{Data: testData}, new(executor.Context))
+	require.ErrorContains(t, err, "cannot init chain config")
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -785,7 +785,8 @@ func (cc *configContext) setChainId() error {
 		}
 
 		if cc.cfg.ChainID == 0 {
-			return fmt.Errorf("ChainID was neither specified with flag (--%v) nor was found in AidaDb (%v); setting default value for mainnet", ChainIDFlag.Name, cc.cfg.AidaDb)
+			cc.log.Warningf("ChainID was neither specified with flag (--%v) nor was found in AidaDb (%v); setting default value for mainnet", ChainIDFlag.Name, cc.cfg.AidaDb)
+			cc.cfg.ChainID = MainnetChainID
 		} else {
 			cc.log.Noticef("Found chainId (%v) in AidaDb", cc.cfg.ChainID)
 		}

--- a/utils/config.go
+++ b/utils/config.go
@@ -370,7 +370,7 @@ type Config struct {
 	Workers                  int                       // number of worker threads
 
 	// -- cached results --
-	chainCfg           *params.ChainConfig   // cached chain configuration
+	ChainCfg           *params.ChainConfig   // cached chain configuration
 	interpreterFactory vm.InterpreterFactory // cached interpreter factory to facilitate reuse in interpreter instances
 	VmCfg              vm.Config
 }
@@ -406,7 +406,7 @@ func NewTestConfig(t *testing.T, chainId ChainID, first, last uint64, validate b
 		ChainID:         chainId,
 		First:           first,
 		Last:            last,
-		chainCfg:        chainCfg,
+		ChainCfg:        chainCfg,
 		LogLevel:        "Critical",
 		SkipPriming:     true,
 		Validate:        validate,
@@ -471,8 +471,8 @@ func NewConfig(ctx *cli.Context, mode ArgumentMode) (*Config, error) {
 }
 
 func (cfg *Config) GetChainConfig(fork string) (*params.ChainConfig, error) {
-	if cfg.chainCfg != nil && fork == "" {
-		return cfg.chainCfg, nil
+	if cfg.ChainCfg != nil && fork == "" {
+		return cfg.ChainCfg, nil
 	}
 	return getChainConfig(cfg.ChainID, fork)
 }
@@ -785,8 +785,7 @@ func (cc *configContext) setChainId() error {
 		}
 
 		if cc.cfg.ChainID == 0 {
-			cc.log.Warningf("ChainID was neither specified with flag (--%v) nor was found in AidaDb (%v); setting default value for mainnet", ChainIDFlag.Name, cc.cfg.AidaDb)
-			cc.cfg.ChainID = MainnetChainID
+			return fmt.Errorf("ChainID was neither specified with flag (--%v) nor was found in AidaDb (%v); setting default value for mainnet", ChainIDFlag.Name, cc.cfg.AidaDb)
 		} else {
 			cc.log.Noticef("Found chainId (%v) in AidaDb", cc.cfg.ChainID)
 		}
@@ -967,7 +966,7 @@ func (cc *configContext) setChainConfig() (err error) {
 	if cc.cfg.ChainID == EthTestsChainID {
 		return nil
 	}
-	cc.cfg.chainCfg, err = getChainConfig(cc.cfg.ChainID, "")
+	cc.cfg.ChainCfg, err = getChainConfig(cc.cfg.ChainID, "")
 	return err
 }
 

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -889,7 +889,7 @@ func TestNewTestConfig_CorrectlyFillsData(t *testing.T) {
 	require.Equal(t, last, cfg.Last, "Last block not set correctly")
 	require.True(t, cfg.Validate, "Validate not set correctly")
 	require.True(t, cfg.ValidateTxState, "ValidateTxState not set correctly")
-	require.NotNil(t, cfg.chainCfg, "chainCfg should be set")
+	require.NotNil(t, cfg.ChainCfg, "ChainCfg should be set")
 	require.Equal(t, "Critical", cfg.LogLevel, "LogLevel should be Critical")
 	require.True(t, cfg.SkipPriming, "SkipPriming should be true")
 	require.True(t, cfg.VmCfg.NoBaseFee, "VmCfg.NoBaseFee should be true")


### PR DESCRIPTION
## Description

This PR forces user to chose chain-id `(--chainind)` when running `ethtest`.
This PR also contains necessary fixes tied with this change.
This might break current pipelines with `ethtest`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

