### PR TITLE
Fix Prague ethtests

### DIFF
--- a/ethtest/block_enviroment.go
+++ b/ethtest/block_enviroment.go
@@ -45,14 +45,6 @@ func (s *stBlockEnvironment) GetCoinbase() common.Address {
 
 func (s *stBlockEnvironment) GetBlobBaseFee() *big.Int {
 	if s.chainCfg.IsCancun(new(big.Int), s.Timestamp.Uint64()) && s.ExcessBlobGas != nil {
-		cancunTime := uint64(0)
-		config := &params.ChainConfig{}
-		config.LondonBlock = big.NewInt(1)
-		config.CancunTime = &cancunTime
-		config.BlobScheduleConfig = &params.BlobScheduleConfig{
-			Cancun: params.DefaultCancunBlobConfig,
-			Prague: params.DefaultPragueBlobConfig,
-		}
 		excessBlobGas := s.ExcessBlobGas.Uint64()
 		header := &types.Header{
 			ExcessBlobGas: &excessBlobGas,

--- a/ethtest/block_enviroment.go
+++ b/ethtest/block_enviroment.go
@@ -47,16 +47,18 @@ func (s *stBlockEnvironment) GetBlobBaseFee() *big.Int {
 	if s.chainCfg.IsCancun(new(big.Int), s.Timestamp.Uint64()) && s.ExcessBlobGas != nil {
 		cancunTime := uint64(0)
 		config := &params.ChainConfig{}
-		config.LondonBlock = big.NewInt(0)
+		config.LondonBlock = big.NewInt(1)
 		config.CancunTime = &cancunTime
 		config.BlobScheduleConfig = &params.BlobScheduleConfig{
 			Cancun: params.DefaultCancunBlobConfig,
+			Prague: params.DefaultPragueBlobConfig,
 		}
 		excessBlobGas := s.ExcessBlobGas.Uint64()
 		header := &types.Header{
 			ExcessBlobGas: &excessBlobGas,
+			RequestsHash:  &types.EmptyRequestsHash,
 		}
-		return eip4844.CalcBlobFee(config, header)
+		return eip4844.CalcBlobFee(s.chainCfg, header)
 	}
 
 	return nil

--- a/ethtest/transaction.go
+++ b/ethtest/transaction.go
@@ -211,18 +211,19 @@ func (tx *stTransaction) toMessage(ps stPost, baseFee *BigInt) (*core.Message, e
 	}
 
 	msg := &core.Message{
-		To:            to,
-		From:          from,
-		Nonce:         tx.Nonce.Uint64(),
-		Value:         value,
-		GasLimit:      gasLimit.Uint64(),
-		GasPrice:      gasPrice.Convert(),
-		GasFeeCap:     tx.MaxFeePerGas.Convert(),
-		GasTipCap:     tx.MaxPriorityFeePerGas.Convert(),
-		Data:          data,
-		AccessList:    accessList,
-		BlobGasFeeCap: tx.BlobGasFeeCap.Convert(),
-		BlobHashes:    tx.BlobHashes,
+		To:                    to,
+		From:                  from,
+		Nonce:                 tx.Nonce.Uint64(),
+		Value:                 value,
+		GasLimit:              gasLimit.Uint64(),
+		GasPrice:              gasPrice.Convert(),
+		GasFeeCap:             tx.MaxFeePerGas.Convert(),
+		GasTipCap:             tx.MaxPriorityFeePerGas.Convert(),
+		Data:                  data,
+		AccessList:            accessList,
+		BlobGasFeeCap:         tx.BlobGasFeeCap.Convert(),
+		BlobHashes:            tx.BlobHashes,
+		SetCodeAuthorizations: authList,
 	}
 	return msg, nil
 }

--- a/ethtest/transaction_test.go
+++ b/ethtest/transaction_test.go
@@ -3,12 +3,12 @@ package ethtest
 import (
 	"encoding/json"
 	"errors"
-	"github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/ethtest/transaction_test.go
+++ b/ethtest/transaction_test.go
@@ -1,8 +1,8 @@
 package ethtest
 
 import (
+	"encoding/json"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/goccy/go-json"
 	"math/big"
 	"testing"
 
@@ -19,6 +19,14 @@ func TestStTransaction_ToMessage(t *testing.T) {
 		ExpectException: "err",
 		Indexes:         Index{Data: 0, Gas: 0, Value: 0},
 	}
+	stAuth := stAuthorization{
+		ChainID: big.NewInt(1),
+		Address: common.HexToAddress("0x9abc"),
+		Nonce:   1,
+		V:       27,
+		R:       big.NewInt(123456789),
+		S:       big.NewInt(987654321),
+	}
 	to := common.HexToAddress("0x1234")
 	bytesTo, err := to.MarshalText()
 	if err != nil {
@@ -33,6 +41,9 @@ func TestStTransaction_ToMessage(t *testing.T) {
 		MaxPriorityFeePerGas: newBigInt(1),
 		BlobGasFeeCap:        newBigInt(1),
 		To:                   string(bytesTo),
+		AuthorizationList: []*stAuthorization{
+			&stAuth,
+		},
 	}
 	msg, err := st.toMessage(post, newBigInt(1))
 	assert.NoError(t, err)
@@ -41,6 +52,7 @@ func TestStTransaction_ToMessage(t *testing.T) {
 	assert.Equal(t, st.BlobGasFeeCap.Convert(), msg.BlobGasFeeCap)
 	assert.Equal(t, []byte{0x12, 0x34}, msg.Data)
 	assert.Equal(t, st.Value[0], msg.Value.String())
+	assert.Equal(t, *st.AuthorizationList[0], stAuth)
 }
 
 func TestStTransaction_ToMessageError(t *testing.T) {

--- a/ethtest/transaction_test.go
+++ b/ethtest/transaction_test.go
@@ -297,39 +297,6 @@ func TestStAuthorization_NothingMustBeNil(t *testing.T) {
 			wantErr: errors.New("missing required field 'chainId' for stAuthorization"),
 		},
 		{
-			name: "Address is nil",
-			auth: stAuthorization{
-				ChainID: big.NewInt(1),
-				Nonce:   1,
-				V:       27,
-				R:       big.NewInt(123456789),
-				S:       big.NewInt(987654321),
-			},
-			wantErr: errors.New("missing required field 'address' for stAuthorization"),
-		},
-		{
-			name: "Nonce is nil",
-			auth: stAuthorization{
-				ChainID: big.NewInt(1),
-				Address: common.HexToAddress("0x9abc"),
-				V:       27,
-				R:       big.NewInt(123456789),
-				S:       big.NewInt(987654321),
-			},
-			wantErr: errors.New("missing required field 'nonce' for stAuthorization"),
-		},
-		{
-			name: "V is nil",
-			auth: stAuthorization{
-				ChainID: big.NewInt(1),
-				Address: common.HexToAddress("0x9abc"),
-				Nonce:   1,
-				R:       big.NewInt(123456789),
-				S:       big.NewInt(987654321),
-			},
-			wantErr: errors.New("missing required field 'v' for stAuthorization"),
-		},
-		{
 			name: "R is nil",
 			auth: stAuthorization{
 				ChainID: big.NewInt(1),
@@ -354,19 +321,13 @@ func TestStAuthorization_NothingMustBeNil(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			marshal, err := json.Marshal(test.auth)
-			if test.wantErr != nil {
-				assert.Error(t, err)
-				assert.Equal(t, test.wantErr.Error(), err.Error())
-				return
-			}
+			marshal, err := test.auth.MarshalJSON()
 			assert.NoError(t, err)
 
 			var unmarshalled stAuthorization
 			err = json.Unmarshal(marshal, &unmarshalled)
-			assert.NoError(t, err)
-
-			assert.Equal(t, test.auth, unmarshalled)
+			assert.Error(t, err)
+			assert.Equal(t, test.wantErr, err)
 		})
 	}
 }

--- a/ethtest/transaction_test.go
+++ b/ethtest/transaction_test.go
@@ -1,6 +1,8 @@
 package ethtest
 
 import (
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/goccy/go-json"
 	"math/big"
 	"testing"
 
@@ -216,4 +218,50 @@ func TestEthTest_bigMin(t *testing.T) {
 	assert.Equal(t, a, bigMin(a, b))
 	assert.Equal(t, a, bigMin(b, a))
 	assert.Equal(t, b, bigMin(b, b))
+}
+
+func TestStTransaction_MarshallAndUnmarshall(t *testing.T) {
+	sender := common.HexToAddress("0x5678")
+	st := stTransaction{
+		Data:                 []string{"0x1234"},
+		Value:                []string{"1234"},
+		GasLimit:             []*BigInt{newBigInt(1000000)},
+		GasPrice:             newBigInt(1),
+		Nonce:                newBigInt(2),
+		MaxFeePerGas:         newBigInt(3),
+		MaxPriorityFeePerGas: newBigInt(4),
+		BlobGasFeeCap:        newBigInt(5),
+		To:                   "0x1234",
+		AccessLists: []*types.AccessList{
+			{
+				{
+					Address:     common.HexToAddress("0x1234"),
+					StorageKeys: []common.Hash{common.HexToHash("0x5678")},
+				},
+			},
+		},
+		PrivateKey: hexutil.MustDecode("0x1234"),
+		Sender:     &sender,
+		AuthorizationList: []*stAuthorization{
+			{
+				ChainID: big.NewInt(1),
+				Address: common.HexToAddress("0x9abc"),
+				Nonce:   1,
+				V:       27,
+				R:       big.NewInt(123456789),
+				S:       big.NewInt(987654321),
+			},
+		},
+		BlobHashes: []common.Hash{
+			common.HexToHash("0xabcdef"),
+		},
+	}
+
+	marshal, err := json.Marshal(st)
+	assert.NoError(t, err)
+	var unmarshalled stTransaction
+	err = json.Unmarshal(marshal, &unmarshalled)
+	assert.NoError(t, err)
+
+	assert.Equal(t, st, unmarshalled)
 }

--- a/ethtest/transaction_test.go
+++ b/ethtest/transaction_test.go
@@ -2,6 +2,7 @@ package ethtest
 
 import (
 	"encoding/json"
+	"errors"
 	"github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"testing"
@@ -276,4 +277,96 @@ func TestStTransaction_MarshallAndUnmarshall(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, st, unmarshalled)
+}
+
+func TestStAuthorization_NothingMustBeNil(t *testing.T) {
+	tests := []struct {
+		name    string
+		auth    stAuthorization
+		wantErr error
+	}{
+		{
+			name: "ChainID is nil",
+			auth: stAuthorization{
+				Address: common.HexToAddress("0x9abc"),
+				Nonce:   1,
+				V:       27,
+				R:       big.NewInt(123456789),
+				S:       big.NewInt(987654321),
+			},
+			wantErr: errors.New("missing required field 'chainId' for stAuthorization"),
+		},
+		{
+			name: "Address is nil",
+			auth: stAuthorization{
+				ChainID: big.NewInt(1),
+				Nonce:   1,
+				V:       27,
+				R:       big.NewInt(123456789),
+				S:       big.NewInt(987654321),
+			},
+			wantErr: errors.New("missing required field 'address' for stAuthorization"),
+		},
+		{
+			name: "Nonce is nil",
+			auth: stAuthorization{
+				ChainID: big.NewInt(1),
+				Address: common.HexToAddress("0x9abc"),
+				V:       27,
+				R:       big.NewInt(123456789),
+				S:       big.NewInt(987654321),
+			},
+			wantErr: errors.New("missing required field 'nonce' for stAuthorization"),
+		},
+		{
+			name: "V is nil",
+			auth: stAuthorization{
+				ChainID: big.NewInt(1),
+				Address: common.HexToAddress("0x9abc"),
+				Nonce:   1,
+				R:       big.NewInt(123456789),
+				S:       big.NewInt(987654321),
+			},
+			wantErr: errors.New("missing required field 'v' for stAuthorization"),
+		},
+		{
+			name: "R is nil",
+			auth: stAuthorization{
+				ChainID: big.NewInt(1),
+				Address: common.HexToAddress("0x9abc"),
+				Nonce:   1,
+				S:       big.NewInt(987654321),
+			},
+			wantErr: errors.New("missing required field 'r' for stAuthorization"),
+		},
+		{
+			name: "S is nil",
+			auth: stAuthorization{
+				ChainID: big.NewInt(1),
+				Address: common.HexToAddress("0x9abc"),
+				Nonce:   1,
+				V:       27,
+				R:       big.NewInt(123456789),
+			},
+			wantErr: errors.New("missing required field 's' for stAuthorization"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			marshal, err := json.Marshal(test.auth)
+			if test.wantErr != nil {
+				assert.Error(t, err)
+				assert.Equal(t, test.wantErr.Error(), err.Error())
+				return
+			}
+			assert.NoError(t, err)
+
+			var unmarshalled stAuthorization
+			err = json.Unmarshal(marshal, &unmarshalled)
+			assert.NoError(t, err)
+
+			assert.Equal(t, test.auth, unmarshalled)
+		})
+	}
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -785,7 +785,8 @@ func (cc *configContext) setChainId() error {
 		}
 
 		if cc.cfg.ChainID == 0 {
-			return fmt.Errorf("ChainID was neither specified with flag (--%v) nor was found in AidaDb (%v); setting default value for mainnet", ChainIDFlag.Name, cc.cfg.AidaDb)
+			cc.log.Warningf("ChainID was neither specified with flag (--%v) nor was found in AidaDb (%v); setting default value for mainnet", ChainIDFlag.Name, cc.cfg.AidaDb)
+			cc.cfg.ChainID = MainnetChainID
 		} else {
 			cc.log.Noticef("Found chainId (%v) in AidaDb", cc.cfg.ChainID)
 		}

--- a/utils/config.go
+++ b/utils/config.go
@@ -785,8 +785,7 @@ func (cc *configContext) setChainId() error {
 		}
 
 		if cc.cfg.ChainID == 0 {
-			cc.log.Warningf("ChainID was neither specified with flag (--%v) nor was found in AidaDb (%v); setting default value for mainnet", ChainIDFlag.Name, cc.cfg.AidaDb)
-			cc.cfg.ChainID = MainnetChainID
+			return fmt.Errorf("ChainID was neither specified with flag (--%v) nor was found in AidaDb (%v); setting default value for mainnet", ChainIDFlag.Name, cc.cfg.AidaDb)
 		} else {
 			cc.log.Noticef("Found chainId (%v) in AidaDb", cc.cfg.ChainID)
 		}


### PR DESCRIPTION
## Description

This PR fixes `eth-tests` ran on `Prague` fork by adding `stAuthorization` for `message.SetCodeAuthorizations` and using already existing `chainCfg` inside `blockEnvironment`

TODO:
- [x] Merge #105 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
