### PR TITLE
Add continue-on-failure flag to aida-vm

### DIFF
--- a/cmd/aida-vm/main.go
+++ b/cmd/aida-vm/main.go
@@ -58,6 +58,8 @@ func main() {
 			&utils.StateDbLoggingFlag,
 			&utils.CacheFlag,
 			&utils.SubstateEncodingFlag,
+			&utils.ContinueOnFailureFlag,
+			&utils.MaxNumErrorsFlag,
 		},
 	}
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
## Description

This PR add `continue-on-failure` flag to aida-vm tool which allows aida-vm to continue even the first failure is found.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
