### PR TITLE
Add cmd tests

### DIFF
--- a/cmd/aida-rpc/main.go
+++ b/cmd/aida-rpc/main.go
@@ -25,55 +25,54 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var rpcApp = &cli.App{
+	Action: RunRpc,
+	Name:   "Replay-RPC",
+	Usage: "Sends real API requests recorded on rpcapi.fantom.network to StateDB then compares recorded" +
+		"result with result returned by DB.",
+	Copyright: "(c) 2023 Fantom Foundation",
+	Flags: []cli.Flag{
+		&utils.RpcRecordingFileFlag,
+		&utils.WorkersFlag,
+
+		// VM
+		&utils.VmImplementation,
+
+		// Config
+		&logger.LogLevelFlag,
+		&utils.ChainIDFlag,
+		&utils.ContinueOnFailureFlag,
+		&utils.ValidateFlag,
+		&utils.NoHeartbeatLoggingFlag,
+		&utils.ErrorLoggingFlag,
+		&utils.TrackProgressFlag,
+
+		// Register
+		&utils.RegisterRunFlag,
+		&utils.OverwriteRunIdFlag,
+
+		// ShadowDB
+		&utils.ShadowDb,
+
+		// StateDB
+		&utils.StateDbSrcFlag,
+		&utils.StateDbLoggingFlag,
+
+		// Trace
+		&utils.TraceFlag,
+		&utils.TraceFileFlag,
+		&utils.TraceDebugFlag,
+
+		// Performance
+		&utils.CpuProfileFlag,
+		&utils.MemoryProfileFlag,
+		&utils.ProfileFlag,
+		&utils.ProfileFileFlag,
+	},
+}
+
 func main() {
-	app := &cli.App{
-		Action: RunRpc,
-		Name:   "Replay-RPC",
-		Usage: "Sends real API requests recorded on rpcapi.fantom.network to StateDB then compares recorded" +
-			"result with result returned by DB.",
-		Copyright: "(c) 2023 Fantom Foundation",
-		Flags: []cli.Flag{
-			&utils.RpcRecordingFileFlag,
-			&utils.WorkersFlag,
-
-			// VM
-			&utils.VmImplementation,
-
-			// Config
-			&logger.LogLevelFlag,
-			&utils.ChainIDFlag,
-			&utils.ContinueOnFailureFlag,
-			&utils.ValidateFlag,
-			&utils.NoHeartbeatLoggingFlag,
-			&utils.ErrorLoggingFlag,
-			&utils.TrackProgressFlag,
-
-			// Register
-			&utils.RegisterRunFlag,
-			&utils.OverwriteRunIdFlag,
-
-			// ShadowDB
-			&utils.ShadowDb,
-
-			// StateDB
-			&utils.StateDbSrcFlag,
-			&utils.StateDbLoggingFlag,
-
-			// Trace
-			&utils.TraceFlag,
-			&utils.TraceFileFlag,
-			&utils.TraceDebugFlag,
-
-			// Performance
-			&utils.CpuProfileFlag,
-			&utils.MemoryProfileFlag,
-			&utils.ProfileFlag,
-			&utils.ProfileFileFlag,
-		},
-	}
-
-	if err := app.Run(os.Args); err != nil {
+	if err := rpcApp.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}
-
 }

--- a/cmd/aida-rpc/rpc_test.go
+++ b/cmd/aida-rpc/rpc_test.go
@@ -17,7 +17,11 @@
 package main
 
 import (
+	"compress/gzip"
 	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+	"os"
 	"strings"
 	"testing"
 
@@ -32,6 +36,45 @@ import (
 )
 
 var testingAddress = "0x0000000000000000000000000000000000000000"
+
+func TestCmd_RunRpc(t *testing.T) {
+	app := cli.NewApp()
+	app.Action = RunRpc
+	app.Flags = []cli.Flag{
+		&utils.RpcRecordingFileFlag,
+		&utils.StateDbSrcFlag,
+	}
+	recordingsDir := t.TempDir()
+	f, err := os.Create(recordingsDir + "/test_record.gz")
+	require.NoError(t, err)
+
+	w := gzip.NewWriter(f)
+	_, err = w.Write([]byte("test_record"))
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
+
+	tmp := t.TempDir()
+	// Create a tmp archive
+	cfg := &utils.Config{
+		DbTmp:          tmp,
+		DbVariant:      "go-file",
+		DbImpl:         "carmen",
+		ArchiveMode:    true,
+		ArchiveVariant: "s5",
+		CarmenSchema:   5,
+	}
+	sdb, archivePath, err := utils.PrepareStateDB(cfg)
+	require.NoError(t, err)
+	err = sdb.Close()
+	require.NoError(t, err)
+
+	err = utils.WriteStateDbInfo(archivePath, cfg, 1, common.Hash{0x13}, true)
+	require.NoError(t, err)
+
+	err = app.Run([]string{rpcApp.Name, "-r", recordingsDir, "--db-src", archivePath, "first", "last"})
+	require.NoError(t, err)
+}
 
 func TestRpc_AllDbEventsAreIssuedInOrder_Sequential(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/cmd/aida-rpc/rpc_test.go
+++ b/cmd/aida-rpc/rpc_test.go
@@ -19,8 +19,7 @@ package main
 import (
 	"compress/gzip"
 	"encoding/json"
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
+
 	"os"
 	"strings"
 	"testing"
@@ -32,6 +31,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 	"go.uber.org/mock/gomock"
 )
 

--- a/cmd/aida-vm-adb/run_vm_adb_test.go
+++ b/cmd/aida-vm-adb/run_vm_adb_test.go
@@ -18,8 +18,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 	"math/big"
 	"strings"
 	"testing"
@@ -33,6 +31,8 @@ import (
 	substatetypes "github.com/0xsoniclabs/substate/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 	"go.uber.org/mock/gomock"
 )
 

--- a/cmd/aida-vm-adb/run_vm_adb_test.go
+++ b/cmd/aida-vm-adb/run_vm_adb_test.go
@@ -39,7 +39,7 @@ import (
 var testingAddress = common.Address{1}
 
 func TestCmd_RunVmAdb(t *testing.T) {
-	_, _, path := utils.CreateTestSubstateDb(t)
+	_, path := utils.CreateTestSubstateDb(t)
 	app := cli.NewApp()
 	app.Action = RunVmAdb
 	app.Flags = []cli.Flag{

--- a/cmd/aida-vm-sdb/run_eth_test.go
+++ b/cmd/aida-vm-sdb/run_eth_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -36,6 +37,17 @@ import (
 	"github.com/holiman/uint256"
 	"go.uber.org/mock/gomock"
 )
+
+func TestCmd_RunEthereumTest(t *testing.T) {
+	app := cli.NewApp()
+	app.Action = RunEthereumTest
+	app.Flags = []cli.Flag{
+		&utils.ChainIDFlag,
+	}
+
+	err := app.Run([]string{RunEthTestsCmd.Name, "--chainid", strconv.Itoa(int(utils.EthTestsChainID)), t.TempDir()})
+	require.NoError(t, err)
+}
 
 func TestVmSdb_Eth_AllDbEventsAreIssuedInOrder(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/cmd/aida-vm-sdb/run_eth_test.go
+++ b/cmd/aida-vm-sdb/run_eth_test.go
@@ -20,13 +20,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
+
 	"strconv"
 	"strings"
 	"testing"
-
-	"github.com/ethereum/go-ethereum/core/tracing"
 
 	"github.com/0xsoniclabs/aida/ethtest"
 	"github.com/0xsoniclabs/aida/executor"
@@ -34,7 +31,10 @@ import (
 	"github.com/0xsoniclabs/aida/txcontext"
 	"github.com/0xsoniclabs/aida/utils"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 	"go.uber.org/mock/gomock"
 )
 

--- a/cmd/aida-vm-sdb/run_substate_test.go
+++ b/cmd/aida-vm-sdb/run_substate_test.go
@@ -18,8 +18,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
+
 	"math/big"
 	"strings"
 	"testing"
@@ -34,6 +33,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 	"go.uber.org/mock/gomock"
 )
 

--- a/cmd/aida-vm-sdb/run_substate_test.go
+++ b/cmd/aida-vm-sdb/run_substate_test.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 	"math/big"
 	"strings"
 	"testing"
@@ -34,6 +36,19 @@ import (
 	"github.com/holiman/uint256"
 	"go.uber.org/mock/gomock"
 )
+
+func TestCmd_RunSubstate(t *testing.T) {
+	_, _, path := utils.CreateTestSubstateDb(t)
+	app := cli.NewApp()
+	app.Action = RunSubstate
+	app.Flags = []cli.Flag{
+		&utils.AidaDbFlag,
+		&utils.SubstateEncodingFlag,
+	}
+
+	err := app.Run([]string{RunSubstateCmd.Name, "--aida-db", path, "--substate-encoding", "pb", "first", "last"})
+	require.ErrorContains(t, err, "nonce too high")
+}
 
 func TestVmSdb_Substate_AllDbEventsAreIssuedInOrder(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/cmd/aida-vm-sdb/run_substate_test.go
+++ b/cmd/aida-vm-sdb/run_substate_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 func TestCmd_RunSubstate(t *testing.T) {
-	_, _, path := utils.CreateTestSubstateDb(t)
+	_, path := utils.CreateTestSubstateDb(t)
 	app := cli.NewApp()
 	app.Action = RunSubstate
 	app.Flags = []cli.Flag{

--- a/cmd/aida-vm-sdb/run_tx_generator_test.go
+++ b/cmd/aida-vm-sdb/run_tx_generator_test.go
@@ -17,6 +17,8 @@
 package main
 
 import (
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 	"math/big"
 	"testing"
 	"time"
@@ -31,6 +33,17 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"go.uber.org/mock/gomock"
 )
+
+func TestCmd_RunTxGenerator(t *testing.T) {
+	app := cli.NewApp()
+	app.Action = RunTxGenerator
+	app.Flags = []cli.Flag{
+		&utils.ForkFlag,
+	}
+
+	err := app.Run([]string{RunTxGeneratorCmd.Name, "--fork", "Prague", "1"})
+	require.NoError(t, err)
+}
 
 func TestVmSdb_TxGenerator_AllTransactionsAreProcessedInOrder(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/cmd/aida-vm-sdb/run_tx_generator_test.go
+++ b/cmd/aida-vm-sdb/run_tx_generator_test.go
@@ -17,8 +17,6 @@
 package main
 
 import (
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 	"math/big"
 	"testing"
 	"time"
@@ -31,6 +29,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 	"go.uber.org/mock/gomock"
 )
 

--- a/cmd/aida-vm/main.go
+++ b/cmd/aida-vm/main.go
@@ -25,42 +25,43 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var runVmApp = &cli.App{
+	Action:    RunVm,
+	Name:      "EVM evaluation tool",
+	HelpName:  "aida-vm",
+	Copyright: "(c) 2023 Fantom Foundation",
+	ArgsUsage: "<blockNumFirst> <blockNumLast>",
+	// TODO: derive supported flags from utilized executor extensions.
+	Flags: []cli.Flag{
+		&utils.WorkersFlag,
+		//&substate.SkipTransferTxsFlag,
+		//&substate.SkipCallTxsFlag,
+		//&substate.SkipCreateTxsFlag,
+		&utils.ChainIDFlag,
+		//&utils.ProfileEVMCallFlag,
+		//&utils.MicroProfilingFlag,
+		//&utils.BasicBlockProfilingFlag,
+		//&utils.ProfilingDbNameFlag,
+		&utils.ChannelBufferSizeFlag,
+		&utils.EvmImplementation,
+		&utils.VmImplementation,
+		&utils.ValidateTxStateFlag,
+		&utils.ValidateFlag,
+		//&utils.OnlySuccessfulFlag,
+		&utils.CpuProfileFlag,
+		&utils.DiagnosticServerFlag,
+		&utils.AidaDbFlag,
+		&logger.LogLevelFlag,
+		&utils.ErrorLoggingFlag,
+		&utils.StateDbImplementationFlag,
+		&utils.StateDbLoggingFlag,
+		&utils.CacheFlag,
+		&utils.SubstateEncodingFlag,
+	},
+}
+
 func main() {
-	app := &cli.App{
-		Action:    RunVm,
-		Name:      "EVM evaluation tool",
-		HelpName:  "aida-vm",
-		Copyright: "(c) 2023 Fantom Foundation",
-		ArgsUsage: "<blockNumFirst> <blockNumLast>",
-		// TODO: derive supported flags from utilized executor extensions.
-		Flags: []cli.Flag{
-			&utils.WorkersFlag,
-			//&substate.SkipTransferTxsFlag,
-			//&substate.SkipCallTxsFlag,
-			//&substate.SkipCreateTxsFlag,
-			&utils.ChainIDFlag,
-			//&utils.ProfileEVMCallFlag,
-			//&utils.MicroProfilingFlag,
-			//&utils.BasicBlockProfilingFlag,
-			//&utils.ProfilingDbNameFlag,
-			&utils.ChannelBufferSizeFlag,
-			&utils.EvmImplementation,
-			&utils.VmImplementation,
-			&utils.ValidateTxStateFlag,
-			&utils.ValidateFlag,
-			//&utils.OnlySuccessfulFlag,
-			&utils.CpuProfileFlag,
-			&utils.DiagnosticServerFlag,
-			&utils.AidaDbFlag,
-			&logger.LogLevelFlag,
-			&utils.ErrorLoggingFlag,
-			&utils.StateDbImplementationFlag,
-			&utils.StateDbLoggingFlag,
-			&utils.CacheFlag,
-			&utils.SubstateEncodingFlag,
-		},
-	}
-	if err := app.Run(os.Args); err != nil {
+	if err := runVmApp.Run(os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/cmd/aida-vm/run_vm_test.go
+++ b/cmd/aida-vm/run_vm_test.go
@@ -18,8 +18,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 	"math/big"
 	"strings"
 	"testing"
@@ -34,6 +32,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 	"go.uber.org/mock/gomock"
 )
 

--- a/cmd/aida-vm/run_vm_test.go
+++ b/cmd/aida-vm/run_vm_test.go
@@ -40,7 +40,7 @@ import (
 var testingAddress = common.Address{1}
 
 func TestCmd_RunVm(t *testing.T) {
-	_, _, path := utils.CreateTestSubstateDb(t)
+	_, path := utils.CreateTestSubstateDb(t)
 	app := cli.NewApp()
 	app.Action = RunVm
 	app.Flags = []cli.Flag{

--- a/cmd/aida-vm/run_vm_test.go
+++ b/cmd/aida-vm/run_vm_test.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 	"math/big"
 	"strings"
 	"testing"
@@ -36,6 +38,19 @@ import (
 )
 
 var testingAddress = common.Address{1}
+
+func TestCmd_RunVm(t *testing.T) {
+	_, _, path := utils.CreateTestSubstateDb(t)
+	app := cli.NewApp()
+	app.Action = RunVm
+	app.Flags = []cli.Flag{
+		&utils.AidaDbFlag,
+		&utils.SubstateEncodingFlag,
+	}
+
+	err := app.Run([]string{runVmApp.Name, "--aida-db", path, "--substate-encoding", "pb", "first", "last"})
+	require.ErrorContains(t, err, "intrinsic gas too low")
+}
 
 func TestVm_AllDbEventsAreIssuedInOrder_Sequential(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/utils/test_utils.go
+++ b/utils/test_utils.go
@@ -2,12 +2,14 @@ package utils
 
 import (
 	"math/big"
+	"testing"
 
 	substateDb "github.com/0xsoniclabs/substate/db"
 	"github.com/0xsoniclabs/substate/substate"
 	"github.com/0xsoniclabs/substate/types"
 	"github.com/0xsoniclabs/substate/updateset"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 )
 
 var testUpdateSet = &updateset.UpdateSet{
@@ -96,4 +98,19 @@ func Must[T any](value T, err error) T {
 		panic(err)
 	}
 	return value
+}
+
+// CreateTestSubstateDb creates a test substate database with a predefined substate.
+func CreateTestSubstateDb(t *testing.T) (substateDb.SubstateDB, *substate.Substate, string) {
+	path := t.TempDir()
+	db, err := substateDb.NewSubstateDB(path, nil, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, db.SetSubstateEncoding(substateDb.ProtobufEncodingSchema))
+
+	ss := GetTestSubstate("protobuf")
+	err = db.PutSubstate(ss)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	return db, ss, path
 }

--- a/utils/test_utils.go
+++ b/utils/test_utils.go
@@ -101,7 +101,7 @@ func Must[T any](value T, err error) T {
 }
 
 // CreateTestSubstateDb creates a test substate database with a predefined substate.
-func CreateTestSubstateDb(t *testing.T) (substateDb.SubstateDB, *substate.Substate, string) {
+func CreateTestSubstateDb(t *testing.T) (*substate.Substate, string) {
 	path := t.TempDir()
 	db, err := substateDb.NewSubstateDB(path, nil, nil, nil)
 	require.NoError(t, err)
@@ -112,5 +112,5 @@ func CreateTestSubstateDb(t *testing.T) (substateDb.SubstateDB, *substate.Substa
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
 
-	return db, ss, path
+	return ss, path
 }

--- a/utils/test_utils_test.go
+++ b/utils/test_utils_test.go
@@ -6,6 +6,7 @@ import (
 	substateDb "github.com/0xsoniclabs/substate/db"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUtils_createTestUpdateDB(t *testing.T) {
@@ -46,4 +47,13 @@ func TestUtils_Must(t *testing.T) {
 	assert.Panics(t, func() {
 		_ = Must(mockFnWithError())
 	})
+}
+
+func TestUtils_CreateTestSubstateDb(t *testing.T) {
+	ss, path := CreateTestSubstateDb(t)
+	sdb, err := substateDb.NewDefaultSubstateDB(path)
+	require.NoError(t, err)
+	gotSs, err := sdb.GetSubstate(ss.Block, ss.Transaction)
+	require.NoError(t, err)
+	require.NoError(t, ss.Equal(gotSs))
 }


### PR DESCRIPTION
## Description

This PR adds cmd tests for `aida-vm` `aida-vm-sdb` `aida-vm-adb` and `aida-rpc`.
Tests for `aida-sdb` should be added #113 and/or #104
Tests for `aida-stochastic-sdb` should be added in #112 

## Type of change

- [ ] Adds or updates testing

