### PR TITLE
Split validate command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,8 @@ install-dev-tools:
 	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.2
 
 format:
-	@goimports -w ./utils ./profile ./txcontext ./ethtest ./rpc ./stochastic ./cmd/util-db/compact ./cmd/util-db/info ./cmd/util-db/merge
-	@gofmt -s -d -w ./utils ./profile ./txcontext ./ethtest ./rpc ./stochastic ./cmd/util-db/compact ./cmd/util-db/info ./cmd/util-db/merge
+	@goimports -w ./utils ./profile ./txcontext ./ethtest ./rpc ./stochastic ./cmd/util-db/compact ./cmd/util-db/info ./cmd/util-db/merge ./cmd/util-db/validate
+	@gofmt -s -d -w ./utils ./profile ./txcontext ./ethtest ./rpc ./stochastic ./cmd/util-db/compact ./cmd/util-db/info ./cmd/util-db/merge ./cmd/util-db/validate
 
 check:
-	@golangci-lint run -c .golangci.yml ./utils ./profile ./txcontext ./ethtest ./rpc ./stochastic ./cmd/util-db/compact ./cmd/util-db/info ./cmd/util-db/merge
+	@golangci-lint run -c .golangci.yml ./utils ./profile ./txcontext ./ethtest ./rpc ./stochastic ./cmd/util-db/compact ./cmd/util-db/info ./cmd/util-db/merge ./cmd/util-db/validate

--- a/cmd/util-db/main.go
+++ b/cmd/util-db/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/0xsoniclabs/aida/cmd/util-db/info"
 	"github.com/0xsoniclabs/aida/cmd/util-db/merge"
 	"github.com/0xsoniclabs/aida/cmd/util-db/primer"
+	"github.com/0xsoniclabs/aida/cmd/util-db/validate"
 	"github.com/urfave/cli/v2"
 )
 
@@ -40,13 +41,11 @@ var UtilDbApp = cli.App{
 		&compact.Command,
 		&merge.Command,
 		&info.Command,
+		&validate.Command,
 		&db.ExtractEthereumGenesisCommand,
 		&db.UpdateCommand,
-		&db.ValidateCommand,
 		&db.GenDeletedAccountsCommand,
-		&db.GenerateDbHashCommand,
 		&db.ScrapeCommand,
-		&db.MetadataCommand,
 
 		//Priming only
 		&primer.RunPrimerCmd,

--- a/cmd/util-db/validate/validate_test.go
+++ b/cmd/util-db/validate/validate_test.go
@@ -1,0 +1,109 @@
+package validate
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/0xsoniclabs/aida/utils"
+	"github.com/0xsoniclabs/substate/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestCmd_ValidateCommand(t *testing.T) {
+	// given
+	_, aidaDbPath := utils.CreateTestSubstateDb(t)
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{&Command}
+
+	args := utils.NewArgs("test").
+		Arg(Command.Name).
+		Flag(utils.AidaDbFlag.Name, aidaDbPath).
+		Build()
+
+	// when
+	err := app.Run(args)
+
+	// then
+	assert.NoError(t, err)
+}
+
+func TestCmd_ValidateCommandError(t *testing.T) {
+	tests := []struct {
+		name        string
+		argsBuilder *utils.ArgsBuilder
+		wantErr     string
+		setup       func(aidaDbPath string)
+	}{
+		{
+			name: "CannotParseCfg",
+			argsBuilder: utils.NewArgs("test").
+				Arg(Command.Name).
+				Flag(utils.ChainIDFlag.Name, 9990099).
+				Flag(utils.AidaDbFlag.Name, ""),
+			wantErr: "cannot parse config",
+			setup:   func(aidaDbPath string) {},
+		},
+		{
+			name: "WrongAidaDbType",
+			argsBuilder: utils.NewArgs("test").
+				Arg(Command.Name),
+			wantErr: fmt.Sprintf("your db type (%v) cannot be validated", utils.NoType),
+			setup: func(aidaDbPath string) {
+				aidaDb, err := db.NewDefaultBaseDB(aidaDbPath)
+				require.NoError(t, err)
+				md := utils.NewAidaDbMetadata(aidaDb, "CRITICAL")
+				err = md.SetDbType(utils.NoType)
+				require.NoError(t, err)
+				err = aidaDb.Close()
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "NoDbHashFound",
+			argsBuilder: utils.NewArgs("test").
+				Arg(Command.Name),
+			wantErr: "could not find expected db hash",
+			setup: func(aidaDbPath string) {
+				aidaDb, err := db.NewDefaultBaseDB(aidaDbPath)
+				require.NoError(t, err)
+				md := utils.NewAidaDbMetadata(aidaDb, "CRITICAL")
+				err = md.SetDbHash([]byte{})
+				require.NoError(t, err)
+				err = aidaDb.Close()
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "WrongDbHash",
+			argsBuilder: utils.NewArgs("test").
+				Arg(Command.Name),
+			wantErr: "hashes are different",
+			setup: func(aidaDbPath string) {
+				aidaDb, err := db.NewDefaultBaseDB(aidaDbPath)
+				require.NoError(t, err)
+				md := utils.NewAidaDbMetadata(aidaDb, "CRITICAL")
+				err = md.SetDbHash([]byte("wrong-hash"))
+				require.NoError(t, err)
+				err = aidaDb.Close()
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, aidaDbPath := utils.CreateTestSubstateDb(t)
+			test.setup(aidaDbPath)
+			app := cli.NewApp()
+			app.Commands = []*cli.Command{&Command}
+			// when
+			test.argsBuilder.Flag(utils.AidaDbFlag.Name, aidaDbPath)
+			err := app.Run(test.argsBuilder.Build())
+
+			// then
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+
+}

--- a/utils/test_utils_test.go
+++ b/utils/test_utils_test.go
@@ -57,3 +57,26 @@ func TestUtils_CreateTestSubstateDb(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, ss.Equal(gotSs))
 }
+func TestArgsBuilder_NewArgs(t *testing.T) {
+	args := NewArgs("test").
+		Arg("a").
+		Arg(0).
+		Arg(false).
+		Arg(true).
+		Flag("f1", "v1").
+		Flag("f2", 0).
+		Flag("f3", false).
+		Flag("f4", true).
+		Build()
+	assert.Equal(t, "test", args[0])
+	assert.Equal(t, "a", args[1])
+	assert.Equal(t, "0", args[2])
+	assert.Equal(t, "false", args[3])
+	assert.Equal(t, "true", args[4])
+	assert.Equal(t, "--f1", args[5])
+	assert.Equal(t, "v1", args[6])
+	assert.Equal(t, "--f2", args[7])
+	assert.Equal(t, "0", args[8])
+	assert.Equal(t, "--f4", args[9])
+	assert.Equal(t, 10, len(args))
+}


### PR DESCRIPTION
## Description

This PR moves `util-db validate` command and any related code to its own package.

## Type of change

- [ ] Refactoring (changes that do NOT affect functionality)
- [ ] Adds or updates testing
