### PR TITLE
Fixing Stochastic Tool

### DIFF
--- a/state/geth.go
+++ b/state/geth.go
@@ -94,11 +94,15 @@ type gethStateDB struct {
 }
 
 func (s *gethStateDB) CreateAccount(addr common.Address) {
-	s.db.CreateAccount(addr)
+	if !s.db.Exist(addr) {
+		s.db.CreateAccount(addr)
+	}
 }
 
 func (s *gethStateDB) CreateContract(addr common.Address) {
-	s.db.CreateContract(addr)
+	if s.db.Exist(addr) {
+		s.db.CreateContract(addr)
+	}
 }
 
 func (s *gethStateDB) Exist(addr common.Address) bool {

--- a/stochastic/event_proxy.go
+++ b/stochastic/event_proxy.go
@@ -49,259 +49,206 @@ func NewEventProxy(db state.StateDB, registry *EventRegistry) *EventProxy {
 
 // CreateAccount creates a new account.
 func (p *EventProxy) CreateAccount(address common.Address) {
-	// register event
 	p.registry.RegisterAddressOp(CreateAccountID, &address)
-
-	// call real StateDB
 	p.db.CreateAccount(address)
+}
+
+// CreateAccount creates a new contract.
+func (p *EventProxy) CreateContract(addr common.Address) {
+	p.registry.RegisterAddressOp(CreateContractID, &addr)
+	p.db.CreateContract(addr)
 }
 
 // SubBalance subtracts amount from a contract address.
 func (p *EventProxy) SubBalance(address common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
-	// register event
 	p.registry.RegisterAddressOp(SubBalanceID, &address)
-
-	// call real StateDB
 	return p.db.SubBalance(address, amount, reason)
 }
 
 // AddBalance adds amount to a contract address.
 func (p *EventProxy) AddBalance(address common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
-	// register event
 	p.registry.RegisterAddressOp(AddBalanceID, &address)
-
-	// call real StateDB
 	return p.db.AddBalance(address, amount, reason)
 }
 
 // GetBalance retrieves the amount of a contract address.
 func (p *EventProxy) GetBalance(address common.Address) *uint256.Int {
-	// register event
 	p.registry.RegisterAddressOp(GetBalanceID, &address)
-
-	// call real StateDB
 	return p.db.GetBalance(address)
 }
 
 // GetNonce retrieves the nonce of a contract address.
 func (p *EventProxy) GetNonce(address common.Address) uint64 {
-	// register event
 	p.registry.RegisterAddressOp(GetNonceID, &address)
-
-	// call real StateDB
 	return p.db.GetNonce(address)
 }
 
 // SetNonce sets the nonce of a contract address.
 func (p *EventProxy) SetNonce(address common.Address, nonce uint64, reason tracing.NonceChangeReason) {
-	// register event
 	p.registry.RegisterAddressOp(SetNonceID, &address)
-
-	// call real StateDB
 	p.db.SetNonce(address, nonce, reason)
 }
 
 // GetCodeHash returns the hash of the EVM bytecode.
 func (p *EventProxy) GetCodeHash(address common.Address) common.Hash {
-	// register event
 	p.registry.RegisterAddressOp(GetCodeHashID, &address)
-
-	// call real StateDB
 	return p.db.GetCodeHash(address)
 }
 
 // GetCode returns the EVM bytecode of a contract.
 func (p *EventProxy) GetCode(address common.Address) []byte {
-	// register event
 	p.registry.RegisterAddressOp(GetCodeID, &address)
-
-	// call real StateDB
 	return p.db.GetCode(address)
 }
 
 // SetCode sets the EVM bytecode of a contract.
 func (p *EventProxy) SetCode(address common.Address, code []byte) []byte {
-	// register event
 	p.registry.RegisterAddressOp(SetCodeID, &address)
-
-	// call real StateDB
 	return p.db.SetCode(address, code)
 }
 
 // GetCodeSize returns the EVM bytecode's size.
 func (p *EventProxy) GetCodeSize(address common.Address) int {
-	// register event
 	p.registry.RegisterAddressOp(GetCodeSizeID, &address)
-
-	// call real StateDB
 	return p.db.GetCodeSize(address)
 }
 
 // AddRefund adds gas to the refund counter.
 func (p *EventProxy) AddRefund(gas uint64) {
-	// call real StateDB
 	p.db.AddRefund(gas)
 }
 
 // SubRefund subtracts gas to the refund counter.
 func (p *EventProxy) SubRefund(gas uint64) {
-	// call real StateDB
 	p.db.SubRefund(gas)
 }
 
 // GetRefund returns the current value of the refund counter.
 func (p *EventProxy) GetRefund() uint64 {
-	// call real StateDB
 	return p.db.GetRefund()
 }
 
 // GetCommittedState retrieves a value that is already committed.
 func (p *EventProxy) GetCommittedState(address common.Address, key common.Hash) common.Hash {
-	// register event
 	p.registry.RegisterKeyOp(GetCommittedStateID, &address, &key)
-
-	// call real StateDB
 	return p.db.GetCommittedState(address, key)
 }
 
 // GetState retrieves a value from the StateDB.
 func (p *EventProxy) GetState(address common.Address, key common.Hash) common.Hash {
-	// register event
 	p.registry.RegisterKeyOp(GetStateID, &address, &key)
-
-	// call real StateDB
 	return p.db.GetState(address, key)
+}
+
+// GetStorageRoot retrieves the root hash of the storage of an address.
+func (p *EventProxy) GetStorageRoot(addr common.Address) common.Hash {
+	p.registry.RegisterAddressOp(GetStorageRootID, &addr)
+	return p.db.GetStorageRoot(addr)
 }
 
 // SetState sets a value in the StateDB.
 func (p *EventProxy) SetState(address common.Address, key common.Hash, value common.Hash) common.Hash {
-	// register event
 	p.registry.RegisterValueOp(SetStateID, &address, &key, &value)
-
-	// call real StateDB
 	return p.db.SetState(address, key, value)
 }
-func (p *EventProxy) SetTransientState(addr common.Address, key common.Hash, value common.Hash) {
-	p.registry.RegisterValueOp(SetTransientStateID, &addr, &key, &value)
-	p.db.SetTransientState(addr, key, value)
-}
 
+// GetTransientState gets a value from the transient storage.
 func (p *EventProxy) GetTransientState(addr common.Address, key common.Hash) common.Hash {
 	p.registry.RegisterKeyOp(GetTransientStateID, &addr, &key)
 	return p.db.GetState(addr, key)
 }
 
-// SelfDestruct an account.
-func (p *EventProxy) SelfDestruct(address common.Address) uint256.Int {
-	// register event
-	p.registry.RegisterAddressOp(SelfDestructID, &address)
+// SetTransientState sets a value in the transient storage.
+func (p *EventProxy) SetTransientState(addr common.Address, key common.Hash, value common.Hash) {
+	p.registry.RegisterValueOp(SetTransientStateID, &addr, &key, &value)
+	p.db.SetTransientState(addr, key, value)
+}
 
-	// call real StateDB
+// SelfDestruct destructs an account.
+func (p *EventProxy) SelfDestruct(address common.Address) uint256.Int {
+	p.registry.RegisterAddressOp(SelfDestructID, &address)
 	return p.db.SelfDestruct(address)
+}
+
+// SelDestruct6780 destructs an account.
+func (p *EventProxy) SelfDestruct6780(addr common.Address) (uint256.Int, bool) {
+	p.registry.RegisterAddressOp(SelfDestruct6780ID, &addr)
+	return p.db.SelfDestruct6780(addr)
 }
 
 // HasSelfDestructed checks whether a contract has been suicided.
 func (p *EventProxy) HasSelfDestructed(address common.Address) bool {
-	// register event
 	p.registry.RegisterAddressOp(HasSelfDestructedID, &address)
-
-	// call real StateDB
 	return p.db.HasSelfDestructed(address)
 }
 
 // Exist checks whether the contract exists in the StateDB.
 func (p *EventProxy) Exist(address common.Address) bool {
-	// register event
 	p.registry.RegisterAddressOp(ExistID, &address)
-
-	// call real StateDB
 	return p.db.Exist(address)
 }
 
 // Empty checks whether the contract is either non-existent
 // or empty according to the EIP161 specification (balance = nonce = code = 0).
 func (p *EventProxy) Empty(address common.Address) bool {
-	// register event
 	p.registry.RegisterAddressOp(EmptyID, &address)
-
-	// call real StateDB
 	return p.db.Empty(address)
 }
 
 // Prepare handles the preparatory steps for executing a state transition.
 func (p *EventProxy) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
-	// call real StateDB
 	p.db.Prepare(rules, sender, coinbase, dest, precompiles, txAccesses)
 }
 
 // AddAddressToAccessList adds an address to the access list.
 func (p *EventProxy) AddAddressToAccessList(address common.Address) {
-	// call real StateDB
 	p.db.AddAddressToAccessList(address)
 }
 
 // AddressInAccessList checks whether an address is in the access list.
 func (p *EventProxy) AddressInAccessList(address common.Address) bool {
-	// call real StateDB
 	return p.db.AddressInAccessList(address)
 }
 
 // SlotInAccessList checks whether the (address, slot)-tuple is in the access list.
 func (p *EventProxy) SlotInAccessList(address common.Address, slot common.Hash) (bool, bool) {
-	// call real StateDB
 	return p.db.SlotInAccessList(address, slot)
 }
 
 // AddSlotToAccessList adds the given (address, slot)-tuple to the access list
 func (p *EventProxy) AddSlotToAccessList(address common.Address, slot common.Hash) {
-	// call real StateDB
 	p.db.AddSlotToAccessList(address, slot)
 }
 
 // RevertToSnapshot reverts all state changes from a given revision.
 func (p *EventProxy) RevertToSnapshot(snapshot int) {
-	// register event
 	p.registry.RegisterOp(RevertToSnapshotID)
-
-	// find snapshot
+	// find snapshot in recordings and record how many snapshots have to be unwound
 	for i, recordedSnapshot := range p.snapshots {
 		if recordedSnapshot == snapshot {
-			// register snapshot delta
 			p.registry.RegisterSnapshotDelta(len(p.snapshots) - i - 1)
-
-			// cull all elements between found snapshot and top-of-stack
-			p.snapshots = p.snapshots[0:i]
+			p.snapshots = p.snapshots[0:i+1]
 			break
 		}
 	}
-
-	// call real StateDB
 	p.db.RevertToSnapshot(snapshot)
 }
 
 // Snapshot returns an identifier for the current revision of the state.
 func (p *EventProxy) Snapshot() int {
-	// register event
 	p.registry.RegisterOp(SnapshotID)
-
-	// call real StateDB
 	snapshot := p.db.Snapshot()
-
-	// add snapshot
 	p.snapshots = append(p.snapshots, snapshot)
-
 	return snapshot
 }
 
 // AddLog adds a log entry.
 func (p *EventProxy) AddLog(log *types.Log) {
-	// call real StateDB
 	p.db.AddLog(log)
 }
 
 // GetLogs retrieves log entries.
 func (p *EventProxy) GetLogs(hash common.Hash, block uint64, blockHash common.Hash) []*types.Log {
-	// call real StateDB
 	return p.db.GetLogs(hash, block, blockHash)
 }
 
@@ -321,33 +268,31 @@ func (p *EventProxy) AddPreimage(address common.Hash, image []byte) {
 	p.db.AddPreimage(address, image)
 }
 
+// AccessEvents retrieves events.
 func (p *EventProxy) AccessEvents() *geth_state.AccessEvents {
 	return p.db.AccessEvents()
 }
 
 // SetTxContext sets the current transaction hash and index.
 func (p *EventProxy) SetTxContext(thash common.Hash, ti int) {
-	// call real StateDB
 	p.db.SetTxContext(thash, ti)
 }
 
 // Finalise the state in StateDB.
 func (p *EventProxy) Finalise(deleteEmptyObjects bool) {
-	// call real StateDB
 	p.db.Finalise(deleteEmptyObjects)
 }
 
 // IntermediateRoot computes the current hash of the StateDB.
 func (p *EventProxy) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
-	// call real StateDB
 	return p.db.IntermediateRoot(deleteEmptyObjects)
 }
 
 // Commit StateDB
 func (p *EventProxy) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, error) {
-	// call real StateDB
 	return p.db.Commit(block, deleteEmptyObjects)
 }
+
 
 func (p *EventProxy) GetHash() (common.Hash, error) {
 	return p.db.GetHash()
@@ -451,17 +396,3 @@ func (p *EventProxy) GetShadowDB() state.StateDB {
 	return p.db.GetShadowDB()
 }
 
-func (p *EventProxy) CreateContract(addr common.Address) {
-	p.registry.RegisterOp(CreateContractID)
-	p.db.CreateContract(addr)
-}
-
-func (p *EventProxy) SelfDestruct6780(addr common.Address) (uint256.Int, bool) {
-	p.registry.RegisterOp(SelfDestruct6780ID)
-	return p.db.SelfDestruct6780(addr)
-}
-
-func (p *EventProxy) GetStorageRoot(addr common.Address) common.Hash {
-	p.registry.RegisterOp(CreateContractID)
-	return p.db.GetStorageRoot(addr)
-}

--- a/stochastic/event_proxy.go
+++ b/stochastic/event_proxy.go
@@ -227,7 +227,7 @@ func (p *EventProxy) RevertToSnapshot(snapshot int) {
 	for i, recordedSnapshot := range p.snapshots {
 		if recordedSnapshot == snapshot {
 			p.registry.RegisterSnapshotDelta(len(p.snapshots) - i - 1)
-			p.snapshots = p.snapshots[0:i+1]
+			p.snapshots = p.snapshots[0 : i]
 			break
 		}
 	}
@@ -292,7 +292,6 @@ func (p *EventProxy) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 func (p *EventProxy) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, error) {
 	return p.db.Commit(block, deleteEmptyObjects)
 }
-
 
 func (p *EventProxy) GetHash() (common.Hash, error) {
 	return p.db.GetHash()
@@ -395,4 +394,3 @@ func (p *EventProxy) GetArchiveBlockHeight() (uint64, bool, error) {
 func (p *EventProxy) GetShadowDB() state.StateDB {
 	return p.db.GetShadowDB()
 }
-

--- a/stochastic/operation.go
+++ b/stochastic/operation.go
@@ -30,6 +30,7 @@ const (
 	BeginSyncPeriodID
 	BeginTransactionID
 	CreateAccountID
+	CreateContractID
 	EmptyID
 	EndBlockID
 	EndSyncPeriodID
@@ -42,19 +43,19 @@ const (
 	GetCommittedStateID
 	GetNonceID
 	GetStateID
+	GetStorageRootID
+	GetTransientStateID
 	HasSelfDestructedID
 	RevertToSnapshotID
+	SelfDestructID
+	SelfDestruct6780ID
 	SetCodeID
 	SetNonceID
 	SetStateID
+	SetTransientStateID
 	SnapshotID
 	SubBalanceID
-	SelfDestructID
-	CreateContractID
-	GetStorageRootID
-	GetTransientStateID
-	SetTransientStateID
-	SelfDestruct6780ID
+
 	// Add new operations below this line
 
 	NumOps
@@ -92,9 +93,9 @@ var opText = map[int]string{
 	SetCodeID:           "SetCode",
 	SetNonceID:          "SetNonce",
 	SetStateID:          "SetState",
+	SetTransientStateID: "SetTransientState",
 	SnapshotID:          "Snapshot",
 	SubBalanceID:        "SubBalance",
-	SetTransientStateID: "SetTransientState",
 }
 
 // opMnemo is a mnemonics table for operations.
@@ -126,9 +127,9 @@ var opMnemo = map[int]string{
 	SetCodeID:           "SC",
 	SetNonceID:          "SO",
 	SetStateID:          "SS",
+	SetTransientStateID: "ST",
 	SnapshotID:          "SN",
 	SubBalanceID:        "SB",
-	SetTransientStateID: "ST",
 }
 
 // opNumArgs is an argument number table for operations.
@@ -160,9 +161,9 @@ var opNumArgs = map[int]int{
 	SetCodeID:           1,
 	SetNonceID:          1,
 	SetStateID:          3,
+	SetTransientStateID: 3,
 	SnapshotID:          0,
 	SubBalanceID:        1,
-	SetTransientStateID: 3,
 }
 
 // opId is an operation ID table.
@@ -193,10 +194,10 @@ var opId = map[string]int{
 	"S6": SelfDestruct6780ID,
 	"SC": SetCodeID,
 	"SO": SetNonceID,
-	"SN": SnapshotID,
-	"SB": SubBalanceID,
 	"SS": SetStateID,
 	"ST": SetTransientStateID,
+	"SN": SnapshotID,
+	"SB": SubBalanceID,
 }
 
 // argMnemo is the argument-class mnemonics table.

--- a/stochastic/replay.go
+++ b/stochastic/replay.go
@@ -408,6 +408,9 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 	case GetStorageRootID:
 		db.GetStorageRoot(addr)
 
+	case GetTransientStateID:
+		db.GetState(addr, key)
+
 	case HasSelfDestructedID:
 		db.HasSelfDestructed(addr)
 
@@ -425,6 +428,18 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 
 			// update active snapshots and perform a rollback in balance log
 			ss.snapshot = ss.snapshot[0:snapshotIdx]
+		}
+
+	case SelfDestructID:
+		db.SelfDestruct(addr)
+		if idx := find(ss.selfDestructed, addrIdx); idx == -1 {
+			ss.selfDestructed = append(ss.selfDestructed, addrIdx)
+		}
+
+	case SelfDestruct6780ID:
+		db.SelfDestruct6780(addr)
+		if idx := find(ss.selfDestructed, addrIdx); idx == -1 {
+			ss.selfDestructed = append(ss.selfDestructed, addrIdx)
 		}
 
 	case SetCodeID:
@@ -445,6 +460,9 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 
 	case SetStateID:
 		db.SetState(addr, key, value)
+
+	case SetTransientStateID:
+		db.SetTransientState(addr, key, value)
 
 	case SnapshotID:
 		id := db.Snapshot()
@@ -470,21 +488,8 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 			}
 			db.SubBalance(addr, uint256.NewInt(value), 0)
 		}
-
-	case SelfDestructID:
-		db.SelfDestruct(addr)
-		if idx := find(ss.selfDestructed, addrIdx); idx == -1 {
-			ss.selfDestructed = append(ss.selfDestructed, addrIdx)
-		}
-
-	case SelfDestruct6780ID:
-		db.SelfDestruct6780(addr)
-		if idx := find(ss.selfDestructed, addrIdx); idx == -1 {
-			ss.selfDestructed = append(ss.selfDestructed, addrIdx)
-		}
-
 	default:
-		ss.log.Fatal("invalid operation")
+		ss.log.Fatal("invalid operation "+opText[op])
 	}
 }
 

--- a/stochastic/replay.go
+++ b/stochastic/replay.go
@@ -297,19 +297,6 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 		msg   string
 	)
 
-	if addrCl == statistics.ZeroValueID || addrCl == statistics.NewValueID {
-		return
-	}
-
-	if op == GetTransientStateID || op == SetTransientStateID {
-		return
-	}
-
-	if op == CreateContractID {
-		return 
-	}
-
-
 	// fetch indexes from index access generators
 	addrIdx := ss.contracts.NextIndex(addrCl)
 	keyIdx := ss.keys.NextIndex(keyCl)
@@ -377,14 +364,10 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 		ss.selfDestructed = []int64{}
 
 	case CreateAccountID:
-		//if !db.Exist(addr) {
-			db.CreateAccount(addr)
-		//}
+		db.CreateAccount(addr)
 
 	case CreateContractID:
-		if db.Exist(addr) {
-			db.CreateContract(addr)
-		}
+		db.CreateContract(addr)
 
 	case EmptyID:
 		db.Empty(addr)


### PR DESCRIPTION
This PR fixes issues in the stochastic tool and in the geth proxy interface. The geth interface has the operations CreateAccount() and CreateContract(), which were not guarded and crashed with more recent go-ethereum versions. Just so you know, the EVM guards these calls, so there is no need to fix them in the go-ethereum repo directly. 

The logging format of the stochastic was changed so that a simple delta debugging tool can reuse the logs.

Some of the StateDB operations in the stochastic and in the Proxy were not encoded correctly.

