### PR TITLE
Protect CreateContract and CreateAccount in geth

### DIFF
--- a/state/geth.go
+++ b/state/geth.go
@@ -94,11 +94,15 @@ type gethStateDB struct {
 }
 
 func (s *gethStateDB) CreateAccount(addr common.Address) {
-	s.db.CreateAccount(addr)
+	if !s.db.Exist(addr) {
+		s.db.CreateAccount(addr)
+	}
 }
 
 func (s *gethStateDB) CreateContract(addr common.Address) {
-	s.db.CreateContract(addr)
+	if s.db.Exist(addr) {
+		s.db.CreateContract(addr)
+	}
 }
 
 func (s *gethStateDB) Exist(addr common.Address) bool {

--- a/state/geth_test.go
+++ b/state/geth_test.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -105,4 +106,26 @@ func TestGethDbReloadData(t *testing.T) {
 	if err = db.Close(); err != nil {
 		t.Fatalf("Failed to close DB: %v", err)
 	}
+}
+
+func TestGethDb_CreateAccountIsProtected(t *testing.T) {
+	dir := t.TempDir()
+	db, err := MakeGethStateDB(dir, "", common.Hash{}, false, nil)
+	require.NoError(t, err)
+	addr := common.Address{0x22}
+	// First create the account
+	db.CreateAccount(addr)
+	// Then recall it - it must not panic
+	db.CreateAccount(addr)
+}
+
+func TestGethDb_CreateContractIsProtected(t *testing.T) {
+	dir := t.TempDir()
+	db, err := MakeGethStateDB(dir, "", common.Hash{}, false, nil)
+	require.NoError(t, err)
+	addr := common.Address{0x22}
+	// First create the contract
+	db.CreateContract(addr)
+	// Then recall it - it must not panic
+	db.CreateContract(addr)
 }


### PR DESCRIPTION
## Description

This PR protects `gethDb` operations `CreateAccount` and `CreateContract` to allow calling it in isolation. 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
