### PR TITLE
Fix snapshots in stochastic

### DIFF
--- a/stochastic/event_proxy.go
+++ b/stochastic/event_proxy.go
@@ -16,6 +16,8 @@
 
 package stochastic
 
+// TODO: Provide Mocking tests for proxy
+
 import (
 	"github.com/0xsoniclabs/aida/state"
 	"github.com/0xsoniclabs/aida/txcontext"
@@ -229,7 +231,7 @@ func (p *EventProxy) RevertToSnapshot(snapshot int) {
 			// remove snapshot from the active snapshot list
 			// i.e., the snapshot given as an argument cannot
 			// be reused for another call to RevertToSnapshot
-			p.snapshots = p.snapshots[0 : i]
+			p.snapshots = p.snapshots[0:i]
 			break
 		}
 	}
@@ -305,6 +307,7 @@ func (p *EventProxy) Error() error {
 
 // GetSubstatePostAlloc gets substate post allocation.
 func (p *EventProxy) GetSubstatePostAlloc() txcontext.WorldState {
+	// call real StateDB
 	return p.db.GetSubstatePostAlloc()
 }
 
@@ -313,42 +316,62 @@ func (p *EventProxy) PrepareSubstate(substate txcontext.WorldState, block uint64
 }
 
 func (p *EventProxy) BeginTransaction(number uint32) error {
+	// register event
 	p.registry.RegisterOp(BeginTransactionID)
+
+	// call real StateDB
 	if err := p.db.BeginTransaction(number); err != nil {
 		return err
 	}
+
 	// clear all snapshots
 	p.snapshots = []int{}
 	return nil
 }
 
 func (p *EventProxy) EndTransaction() error {
+	// register event
 	p.registry.RegisterOp(EndTransactionID)
+
+	// call real StateDB
 	if err := p.db.EndTransaction(); err != nil {
 		return err
 	}
+
 	// clear all snapshots
 	p.snapshots = []int{}
 	return nil
 }
 
 func (p *EventProxy) BeginBlock(number uint64) error {
+	// register event
 	p.registry.RegisterOp(BeginBlockID)
+
+	// call real StateDB
 	return p.db.BeginBlock(number)
 }
 
 func (p *EventProxy) EndBlock() error {
+	// register event
 	p.registry.RegisterOp(EndBlockID)
+
+	// call real StateDB
 	return p.db.EndBlock()
 }
 
 func (p *EventProxy) BeginSyncPeriod(number uint64) {
+	// register event
 	p.registry.RegisterOp(BeginSyncPeriodID)
+
+	// call real StateDB
 	p.db.BeginSyncPeriod(number)
 }
 
 func (p *EventProxy) EndSyncPeriod() {
+	// register event
 	p.registry.RegisterOp(EndSyncPeriodID)
+
+	// call real StateDB
 	p.db.EndSyncPeriod()
 }
 

--- a/stochastic/replay.go
+++ b/stochastic/replay.go
@@ -461,7 +461,7 @@ func (ss *stochasticState) execute(op int, addrCl int, keyCl int, valueCl int) {
 			if ss.traceDebug {
 				ss.log.Infof(" id: %v", snapshot)
 			}
-			ss.snapshot = ss.snapshot[:snapshotIdx+1]
+			ss.snapshot = ss.snapshot[:snapshotIdx]
 
 			// update active snapshots and perform a rollback in balance log
 			db.RevertToSnapshot(snapshot)


### PR DESCRIPTION
We had the wrong assumption that StateDB snapshots can be used. For example, the following code snippet would crash. 
```
  x = db.Snapshot()
  db.RevertToSnapshot(x)
  db.RevertToSnapshot(x)
```

In the stochastic tool, the proxy used for recording stochastic events and the replay makes the assumption that snapshots can be reused. This PR corrects the assumption.
