### PR TITLE
Refactor license header check to use Go script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
 
         stage('Check license headers') {
             steps {
-                sh 'cd scripts/license && chmod +x add_license_header.sh && ./add_license_header.sh --check'
+                sh 'make check-license'
             }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,8 @@ clean:
 	cd ../tosca ; \
 	make clean ; \
 	cd .. ; \
-	rm -fr ./build/*
+	rm -fr ./build/* ; \
+	rm -f ./scripts/license/add_license_header_go
 
 help: Makefile
 	@echo "Choose a make command in "$(PROJECT)":"
@@ -137,4 +138,9 @@ check:
 	@golangci-lint run -c .golangci.yml ./...
 
 check-license:
-	@cd scripts/license && chmod +x add_license_header.sh && ./add_license_header.sh --check
+	@cd scripts/license && go build -o add_license_header_go add_license_header.go
+	@cd scripts/license && chmod +x add_license_header_go && ./add_license_header_go --root ../.. --dry-run
+
+add-license:
+	@cd scripts/license && go build -o add_license_header_go add_license_header.go
+	@cd scripts/license && chmod +x add_license_header_go && ./add_license_header_go --root ../..

--- a/scripts/license/add_license_header.go
+++ b/scripts/license/add_license_header.go
@@ -1,0 +1,600 @@
+// Copyright 2025 Sonic Labs
+// This file is part of Aida Testing Infrastructure for Sonic
+//
+// Aida is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Aida is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Aida. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	copyrightYear   = "2025"
+	copyrightHolder = "Sonic Labs"
+
+	// Embedded license header content
+	defaultLicenseHeader = `Copyright 2025 Sonic Labs
+This file is part of Aida Testing Infrastructure for Sonic
+
+Aida is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Aida is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with Aida. If not, see <http://www.gnu.org/licenses/>.`
+)
+
+var (
+	rootDir        = flag.String("root", "", "Root directory to process (required)")
+	ignorePatterns = flag.String("ignore", "carmen/,sonic/,tosca/,mock.go", "Comma-separated list of patterns to ignore")
+	licenseFile    = flag.String("license-file", "", "Path to license header file (uses embedded license if not specified)")
+	dryRun         = flag.Bool("dry-run", false, "Check mode: only check if license headers are correct, don't modify files")
+	verbose        = flag.Bool("verbose", false, "Verbose output: show all processed files")
+)
+
+// FileStatus represents the status of a file's license header
+type FileStatus int
+
+const (
+	StatusCorrect FileStatus = iota
+	StatusMissing
+	StatusUpdated
+	StatusSkipped
+)
+
+// FileResult holds the result of processing a file
+type FileResult struct {
+	Path   string
+	Status FileStatus
+	Error  error
+}
+
+// extendLicenseHeader takes license content and prefixes each line with the comment character
+func extendLicenseHeader(commentPrefix string, licenseContent string) string {
+	var builder strings.Builder
+	scanner := bufio.NewScanner(strings.NewReader(licenseContent))
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			builder.WriteString(commentPrefix + "\n")
+		} else {
+			builder.WriteString(commentPrefix + " " + line + "\n")
+		}
+	}
+
+	return builder.String()
+}
+
+// readLicenseFromFile reads the license header from a file
+func readLicenseFromFile(licenseFilePath string) (string, error) {
+	content, err := os.ReadFile(licenseFilePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read license file: %w", err)
+	}
+	return string(content), nil
+}
+
+// shouldIgnore checks if a file path matches any ignore pattern
+func shouldIgnore(path string, rootDir string, patterns []string) bool {
+	relPath, err := filepath.Rel(rootDir, path)
+	if err != nil {
+		return false
+	}
+
+	// Check if any directory component starts with "."
+	parts := strings.Split(relPath, string(filepath.Separator))
+	for _, part := range parts {
+		if strings.HasPrefix(part, ".") && part != "." {
+			return true
+		}
+	}
+
+	for _, pattern := range patterns {
+		if strings.Contains(relPath, pattern) {
+			return true
+		}
+		if strings.HasSuffix(relPath, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// readFileLines reads a file and returns its lines
+func readFileLines(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return lines, nil
+}
+
+// trimWhitespace trims leading and trailing whitespace from a string
+func trimWhitespace(s string) string {
+	return strings.TrimSpace(s)
+}
+
+// Step 1: List all files with the given extension
+func listAllFiles(rootDir string, fileExtension string) ([]string, error) {
+	var files []string
+
+	err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories
+		if info.IsDir() {
+			return nil
+		}
+
+		// Check if file has the correct extension
+		if strings.HasSuffix(path, fileExtension) {
+			files = append(files, path)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to list files: %w", err)
+	}
+
+	return files, nil
+}
+
+// Step 2: Filter out files that match ignore patterns
+func filterIgnoredFiles(files []string, rootDir string, patterns []string) []string {
+	var filtered []string
+
+	for _, file := range files {
+		if !shouldIgnore(file, rootDir, patterns) {
+			filtered = append(filtered, file)
+		}
+	}
+
+	return filtered
+}
+
+// Step 3: Check which files need license header updates
+func checkFilesNeedUpdate(files []string, licenseHeader string) (map[string]bool, error) {
+	needsUpdate := make(map[string]bool)
+
+	for _, file := range files {
+		hasCorrectHeader, _, err := checkLicenseHeader(file, licenseHeader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check %s: %w", file, err)
+		}
+		needsUpdate[file] = !hasCorrectHeader
+	}
+
+	return needsUpdate, nil
+}
+
+// Step 4: Apply license headers to files (or dry-run)
+func applyLicenseHeaders(files []string, needsUpdate map[string]bool, licenseHeader string, commentPrefix string, dryRun bool) []FileResult {
+	results := make([]FileResult, 0, len(files))
+
+	for _, file := range files {
+		result := FileResult{Path: file}
+
+		if !needsUpdate[file] {
+			result.Status = StatusCorrect
+			results = append(results, result)
+			continue
+		}
+
+		if dryRun {
+			result.Status = StatusMissing
+		} else {
+			err := addLicenseToFile(file, licenseHeader, commentPrefix)
+			if err != nil {
+				result.Error = err
+				result.Status = StatusSkipped
+			} else {
+				result.Status = StatusUpdated
+			}
+		}
+
+		results = append(results, result)
+	}
+
+	return results
+}
+
+// checkLicenseHeader checks if the file has the correct license header
+func checkLicenseHeader(filePath string, licenseHeader string) (bool, int, error) {
+	fileLines, err := readFileLines(filePath)
+	if err != nil {
+		return false, 0, err
+	}
+
+	licenseLines := strings.Split(strings.TrimRight(licenseHeader, "\n"), "\n")
+
+	// Check if each line of the license header matches the file
+	for i, licenseLine := range licenseLines {
+		if i >= len(fileLines) {
+			return false, i + 1, nil
+		}
+
+		if trimWhitespace(fileLines[i]) != trimWhitespace(licenseLine) {
+			return false, i + 1, nil
+		}
+	}
+
+	// Check if the line after the license header is empty or whitespace-only
+	lineAfterHeader := len(licenseLines)
+	if lineAfterHeader < len(fileLines) {
+		if trimWhitespace(fileLines[lineAfterHeader]) != "" {
+			return false, lineAfterHeader + 1, nil
+		}
+	}
+
+	return true, 0, nil
+}
+
+// findContentStart finds the line number where the actual content starts (after old header)
+func findContentStart(filePath string, commentPrefix string) (int, error) {
+	fileLines, err := readFileLines(filePath)
+	if err != nil {
+		return 0, err
+	}
+
+	commentPattern := regexp.MustCompile(`^` + regexp.QuoteMeta(commentPrefix))
+
+	// Find first line that doesn't match the comment prefix
+	for i, line := range fileLines {
+		if !commentPattern.MatchString(line) {
+			// Check for C++ style comments /* */
+			if i == 0 && strings.TrimSpace(line) == "/*" {
+				// Find the closing */
+				for j := i + 1; j < len(fileLines); j++ {
+					if strings.Contains(fileLines[j], "*/") {
+						return j + 2, nil // +2 to skip the */ line and the blank line after
+					}
+				}
+			}
+			return i, nil
+		}
+	}
+
+	return len(fileLines), nil
+}
+
+// addLicenseToFile adds or updates the license header in a file
+func addLicenseToFile(filePath string, licenseHeader string, commentPrefix string) error {
+	// Find where the actual content starts
+	startLine, err := findContentStart(filePath, commentPrefix)
+	if err != nil {
+		return err
+	}
+
+	fileLines, err := readFileLines(filePath)
+	if err != nil {
+		return err
+	}
+
+	// Build new content
+	var builder strings.Builder
+	builder.WriteString(licenseHeader)
+	builder.WriteString("\n") // Add blank line after license header
+
+	// Append the rest of the file content
+	if startLine < len(fileLines) {
+		for i := startLine; i < len(fileLines); i++ {
+			builder.WriteString(fileLines[i] + "\n")
+		}
+	}
+
+	// Write the new content
+	err = os.WriteFile(filePath, []byte(builder.String()), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	return nil
+}
+
+// processFiles orchestrates the four-step pipeline for processing files
+func processFiles(rootDir string, fileExtension string, commentPrefix string, licenseHeader string, patterns []string, dryRun bool) ([]FileResult, error) {
+	// Step 1: List all files
+	if *verbose {
+		fmt.Printf("Step 1: Listing all %s files...\n", fileExtension)
+	}
+	allFiles, err := listAllFiles(rootDir, fileExtension)
+	if err != nil {
+		return nil, err
+	}
+	if *verbose {
+		fmt.Printf("  Found %d files\n", len(allFiles))
+	}
+
+	// Step 2: Filter ignored files
+	if *verbose {
+		fmt.Printf("Step 2: Filtering ignored paths...\n")
+	}
+	filteredFiles := filterIgnoredFiles(allFiles, rootDir, patterns)
+	if *verbose {
+		fmt.Printf("  %d files after filtering (%d ignored)\n", len(filteredFiles), len(allFiles)-len(filteredFiles))
+	}
+
+	// Step 3: Check which files need updates
+	if *verbose {
+		fmt.Printf("Step 3: Checking license headers...\n")
+	}
+	needsUpdate, err := checkFilesNeedUpdate(filteredFiles, licenseHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	updateCount := 0
+	for _, needs := range needsUpdate {
+		if needs {
+			updateCount++
+		}
+	}
+	if *verbose {
+		fmt.Printf("  %d files need updates, %d files are correct\n", updateCount, len(filteredFiles)-updateCount)
+	}
+
+	// Step 4: Apply changes (or dry-run)
+	if *verbose {
+		if dryRun {
+			fmt.Printf("Step 4: Dry-run mode - no changes will be made\n")
+		} else {
+			fmt.Printf("Step 4: Applying license headers...\n")
+		}
+	}
+	results := applyLicenseHeaders(filteredFiles, needsUpdate, licenseHeader, commentPrefix, dryRun)
+
+	return results, nil
+}
+
+// logResults prints a summary of processing results
+func logResults(results []FileResult, fileType string, dryRun bool) int {
+	errorCount := 0
+	correctCount := 0
+	missingCount := 0
+	updatedCount := 0
+	skippedCount := 0
+
+	for _, result := range results {
+		relPath := result.Path
+		if len(relPath) > 80 {
+			relPath = "..." + relPath[len(relPath)-77:]
+		}
+
+		switch result.Status {
+		case StatusCorrect:
+			correctCount++
+			if *verbose {
+				fmt.Printf("  [OK] %s\n", relPath)
+			}
+		case StatusMissing:
+			missingCount++
+			errorCount++
+			fmt.Printf("  [MISSING] %s\n", relPath)
+		case StatusUpdated:
+			updatedCount++
+			fmt.Printf("  [UPDATED] %s\n", relPath)
+		case StatusSkipped:
+			skippedCount++
+			errorCount++
+			fmt.Printf("  [ERROR] %s: %v\n", relPath, result.Error)
+		}
+	}
+
+	fmt.Printf("\nSummary for %s files:\n", fileType)
+	fmt.Printf("  Total: %d\n", len(results))
+	fmt.Printf("  Correct: %d\n", correctCount)
+	if dryRun {
+		fmt.Printf("  Missing headers: %d\n", missingCount)
+	} else {
+		fmt.Printf("  Updated: %d\n", updatedCount)
+	}
+	if skippedCount > 0 {
+		fmt.Printf("  Errors: %d\n", skippedCount)
+	}
+
+	return errorCount
+}
+
+// updateCliAppCopyright updates the copyright in cli.App definitions
+func updateCliAppCopyright(rootDir string, checkOnly bool) int {
+	errorCount := 0
+	cmdDir := filepath.Join(rootDir, "cmd")
+
+	copyrightPattern := regexp.MustCompile(`Copyright:\s*"[^"]*"`)
+	replacement := fmt.Sprintf(`Copyright: "(c) %s %s"`, copyrightYear, copyrightHolder)
+	oldCopyright := `Copyright: "(c) 2022 Fantom Foundation"`
+
+	err := filepath.Walk(cmdDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		contentStr := string(content)
+
+		// Check if file contains cli.App
+		if !strings.Contains(contentStr, "cli.App{") {
+			return nil
+		}
+
+		if checkOnly {
+			if strings.Contains(contentStr, oldCopyright) {
+				fmt.Printf("  [MISSING] %s (obsolete cli.App copyright)\n", path)
+				errorCount++
+			}
+		} else {
+			// Replace the copyright
+			newContent := copyrightPattern.ReplaceAllString(contentStr, replacement)
+			if newContent != contentStr {
+				err = os.WriteFile(path, []byte(newContent), 0644)
+				if err != nil {
+					fmt.Printf("  [ERROR] %s: %v\n", path, err)
+					errorCount++
+					return nil
+				}
+				fmt.Printf("  [UPDATED] %s (cli.App copyright)\n", path)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		fmt.Printf("  [ERROR] Failed to walk cmd directory: %v\n", err)
+		errorCount++
+	}
+
+	return errorCount
+}
+
+func main() {
+	flag.Parse()
+
+	// Validate required parameter
+	if *rootDir == "" {
+		fmt.Fprintf(os.Stderr, "Error: --root parameter is required\n\n")
+		fmt.Fprintf(os.Stderr, "Usage: %s --root <directory> [options]\n\n", os.Args[0])
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	// Clean and validate the root directory
+	rootDirectory := filepath.Clean(*rootDir)
+
+	// Check if directory exists
+	if _, err := os.Stat(rootDirectory); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Error: Root directory does not exist: %s\n", rootDirectory)
+		os.Exit(1)
+	}
+
+	// Parse ignore patterns from comma-separated string
+	patterns := strings.Split(*ignorePatterns, ",")
+	for i := range patterns {
+		patterns[i] = strings.TrimSpace(patterns[i])
+	}
+
+	// Get license content
+	var licenseContent string
+	if *licenseFile != "" {
+		// Use custom license file
+		content, err := readLicenseFromFile(*licenseFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading license file: %v\n", err)
+			os.Exit(1)
+		}
+		licenseContent = content
+	} else {
+		// Use embedded license
+		licenseContent = defaultLicenseHeader
+	}
+
+	fmt.Printf("License Header Tool\n")
+	fmt.Printf("===================\n")
+	fmt.Printf("Root directory: %s\n", rootDirectory)
+	if *licenseFile != "" {
+		fmt.Printf("License file: %s\n", *licenseFile)
+	} else {
+		fmt.Printf("License: embedded (default)\n")
+	}
+	fmt.Printf("Ignore patterns: %s\n", strings.Join(patterns, ", "))
+	if *dryRun {
+		fmt.Printf("Mode: DRY-RUN (checking only, no changes will be made)\n")
+	} else {
+		fmt.Printf("Mode: UPDATE (files will be modified)\n")
+	}
+	fmt.Printf("\n")
+
+	// Extend license header for Go files
+	licenseHeader := extendLicenseHeader("//", licenseContent)
+
+	totalErrors := 0
+
+	// Process .go files
+	fmt.Println("Processing .go files")
+	fmt.Println("====================")
+	results, err := processFiles(rootDirectory, ".go", "//", licenseHeader, patterns, *dryRun)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error processing .go files: %v\n", err)
+		os.Exit(1)
+	}
+	totalErrors += logResults(results, ".go", *dryRun)
+
+	// Update copyright in cli.App definitions
+	fmt.Println("\nProcessing cli.App copyright updates")
+	fmt.Println("=====================================")
+	errors := updateCliAppCopyright(rootDirectory, *dryRun)
+	totalErrors += errors
+
+	// Final summary
+	fmt.Printf("\n")
+	fmt.Printf("===================\n")
+	fmt.Printf("Final Summary\n")
+	fmt.Printf("===================\n")
+	if *dryRun {
+		if totalErrors > 0 {
+			fmt.Printf("❌ Found %d file(s) with missing or incorrect license headers\n", totalErrors)
+			fmt.Printf("Run without --dry-run to fix them\n")
+		} else {
+			fmt.Printf("✅ All files have correct license headers\n")
+		}
+	} else {
+		if totalErrors > 0 {
+			fmt.Printf("⚠️  Completed with %d error(s)\n", totalErrors)
+		} else {
+			fmt.Printf("✅ All files updated successfully\n")
+		}
+	}
+
+	if totalErrors > 0 {
+		os.Exit(1)
+	}
+}

--- a/scripts/license/add_license_header_test.go
+++ b/scripts/license/add_license_header_test.go
@@ -1,0 +1,842 @@
+// Copyright 2025 Sonic Labs
+// This file is part of Aida Testing Infrastructure for Sonic
+//
+// Aida is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Aida is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Aida. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtendLicenseHeader(t *testing.T) {
+	tests := []struct {
+		name           string
+		commentPrefix  string
+		licenseContent string
+		expected       string
+		shouldError    bool
+	}{
+		{
+			name:           "Basic license with comment prefix",
+			commentPrefix:  "//",
+			licenseContent: "Copyright 2025\nLicense text",
+			expected:       "// Copyright 2025\n// License text\n",
+			shouldError:    false,
+		},
+		{
+			name:           "License with empty lines",
+			commentPrefix:  "//",
+			licenseContent: "Copyright 2025\n\nLicense text",
+			expected:       "// Copyright 2025\n//\n// License text\n",
+			shouldError:    false,
+		},
+		{
+			name:           "Python style comments",
+			commentPrefix:  "#",
+			licenseContent: "Copyright 2025",
+			expected:       "# Copyright 2025\n",
+			shouldError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extendLicenseHeader(tt.commentPrefix, tt.licenseContent)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestReadLicenseFromFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	licenseFile := filepath.Join(tmpDir, "license.txt")
+	content := "Test License\nLine 2"
+	err := os.WriteFile(licenseFile, []byte(content), 0644)
+	require.NoError(t, err, "Failed to create test license file")
+
+	result, err := readLicenseFromFile(licenseFile)
+	assert.NoError(t, err, "Unexpected error")
+	assert.Equal(t, content, result)
+}
+
+func TestReadLicenseFromFile_NotFound(t *testing.T) {
+	_, err := readLicenseFromFile("/nonexistent/file.txt")
+	assert.Error(t, err, "Expected error for nonexistent file")
+	assert.Contains(t, err.Error(), "failed to read license file")
+}
+
+func TestShouldIgnore(t *testing.T) {
+	tmpDir := t.TempDir()
+	patterns := []string{"carmen/", "sonic/", "tosca/", "mock.go"}
+
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "Carmen directory",
+			path:     filepath.Join(tmpDir, "carmen", "file.go"),
+			expected: true,
+		},
+		{
+			name:     "Sonic directory",
+			path:     filepath.Join(tmpDir, "sonic", "file.go"),
+			expected: true,
+		},
+		{
+			name:     "Tosca directory",
+			path:     filepath.Join(tmpDir, "tosca", "file.go"),
+			expected: true,
+		},
+		{
+			name:     "Mock file",
+			path:     filepath.Join(tmpDir, "test_mock.go"),
+			expected: true,
+		},
+		{
+			name:     "Hidden directory",
+			path:     filepath.Join(tmpDir, ".git", "config"),
+			expected: true,
+		},
+		{
+			name:     "Regular file",
+			path:     filepath.Join(tmpDir, "regular.go"),
+			expected: false,
+		},
+		{
+			name:     "Nested regular file",
+			path:     filepath.Join(tmpDir, "executor", "executor.go"),
+			expected: false,
+		},
+		{
+			name:     "File with mock in middle",
+			path:     filepath.Join(tmpDir, "executor", "executor_mock.go"),
+			expected: true,
+		},
+		{
+			name:     "Hidden file in root",
+			path:     filepath.Join(tmpDir, ".hidden"),
+			expected: true,
+		},
+		{
+			name:     "File in tosca directory",
+			path:     filepath.Join(tmpDir, "tosca", "file.go"),
+			expected: true,
+		},
+		{
+			name:     "File in sonic directory",
+			path:     filepath.Join(tmpDir, "sonic", "subdir", "file.go"),
+			expected: true,
+		},
+		{
+			name:     "Deeply nested mock file",
+			path:     filepath.Join(tmpDir, "a", "b", "c", "test_mock.go"),
+			expected: true,
+		},
+		{
+			name:     "File ending with mock.go pattern",
+			path:     filepath.Join(tmpDir, "executor", "some_mock.go"),
+			expected: true,
+		},
+		{
+			name:     "File in carmen subdirectory",
+			path:     filepath.Join(tmpDir, "carmen", "subdir", "file.go"),
+			expected: true,
+		},
+		{
+			name:     "File named exactly 'carmen'",
+			path:     filepath.Join(tmpDir, "somedir", "carmen"),
+			expected: false, // Files named 'carmen' are not ignored unless in a carmen/ directory
+		},
+		{
+			name:     "File named exactly 'tosca'",
+			path:     filepath.Join(tmpDir, "dir", "tosca"),
+			expected: false, // Files named 'tosca' are not ignored unless in a tosca/ directory
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldIgnore(tt.path, tmpDir, patterns)
+			assert.Equal(t, tt.expected, result, "for path %s", tt.path)
+		})
+	}
+}
+
+func TestShouldIgnore_CurrentDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	patterns := []string{"carmen/", "mock.go"}
+	// Test with "." as part of path
+	result := shouldIgnore(tmpDir, tmpDir, patterns)
+	assert.False(t, result, "Current directory should not be ignored")
+}
+
+func TestShouldIgnore_InvalidPath(t *testing.T) {
+	// Test with paths where relative path calculation results in .. components
+	// These should be ignored since .. starts with .
+	patterns := []string{"carmen/", "mock.go"}
+	result := shouldIgnore("/some/path/file.go", "/completely/different/root", patterns)
+	assert.True(t, result, "Paths with .. components should be ignored")
+}
+
+func TestReadFileLines(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		content     string
+		expected    []string
+		shouldError bool
+	}{
+		{
+			name:        "Single line",
+			content:     "Line 1",
+			expected:    []string{"Line 1"},
+			shouldError: false,
+		},
+		{
+			name:        "Multiple lines",
+			content:     "Line 1\nLine 2\nLine 3",
+			expected:    []string{"Line 1", "Line 2", "Line 3"},
+			shouldError: false,
+		},
+		{
+			name:        "Empty file",
+			content:     "",
+			expected:    nil, // readFileLines returns nil for empty files, which is equivalent to []string{}
+			shouldError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testFile := filepath.Join(tmpDir, "test.txt")
+			err := os.WriteFile(testFile, []byte(tt.content), 0644)
+			require.NoError(t, err, "Failed to create test file")
+
+			lines, err := readFileLines(testFile)
+			if tt.shouldError {
+				assert.Error(t, err, "Expected error but got none")
+			} else {
+				assert.NoError(t, err, "Unexpected error")
+				assert.Equal(t, tt.expected, lines)
+			}
+		})
+	}
+}
+
+func TestReadFileLines_NonExistent(t *testing.T) {
+	_, err := readFileLines("/nonexistent/file.txt")
+	assert.Error(t, err, "Expected error for nonexistent file")
+}
+
+func TestTrimWhitespace(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"  hello  ", "hello"},
+		{"\t\nworld\n\t", "world"},
+		{"no-whitespace", "no-whitespace"},
+		{"   ", ""},
+	}
+
+	for _, tt := range tests {
+		result := trimWhitespace(tt.input)
+		assert.Equal(t, tt.expected, result, "trimWhitespace(%q)", tt.input)
+	}
+}
+
+func TestCheckLicenseHeader(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name            string
+		fileContent     string
+		licenseHeader   string
+		expectedMatch   bool
+		expectedLineNum int
+	}{
+		{
+			name:            "Correct header with blank line",
+			fileContent:     "// Copyright 2025\n// License text\n\npackage main",
+			licenseHeader:   "// Copyright 2025\n// License text",
+			expectedMatch:   true,
+			expectedLineNum: 0,
+		},
+		{
+			name:            "Incorrect header",
+			fileContent:     "// Wrong copyright\n// License text\n\npackage main",
+			licenseHeader:   "// Copyright 2025\n// License text",
+			expectedMatch:   false,
+			expectedLineNum: 1,
+		},
+		{
+			name:            "Missing blank line after header",
+			fileContent:     "// Copyright 2025\n// License text\npackage main",
+			licenseHeader:   "// Copyright 2025\n// License text",
+			expectedMatch:   false,
+			expectedLineNum: 3,
+		},
+		{
+			name:            "Incomplete header",
+			fileContent:     "// Copyright 2025\n",
+			licenseHeader:   "// Copyright 2025\n// License text",
+			expectedMatch:   false,
+			expectedLineNum: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testFile := filepath.Join(tmpDir, "test.go")
+			err := os.WriteFile(testFile, []byte(tt.fileContent), 0644)
+			require.NoError(t, err, "Failed to create test file")
+
+			match, lineNum, err := checkLicenseHeader(testFile, tt.licenseHeader)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedMatch, match)
+			assert.Equal(t, tt.expectedLineNum, lineNum)
+		})
+	}
+}
+
+func TestCheckLicenseHeader_NonExistent(t *testing.T) {
+	_, _, err := checkLicenseHeader("/nonexistent/file.go", "// Header")
+	assert.Error(t, err, "Expected error for nonexistent file")
+}
+
+func TestFindContentStart(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		content     string
+		prefix      string
+		expected    int
+		shouldError bool
+	}{
+		{
+			name:        "C++ style comment block",
+			content:     "/*\n * Copyright 2025\n */\n\npackage main",
+			prefix:      "//",
+			expected:    4,
+			shouldError: false,
+		},
+		{
+			name:        "Single line comments",
+			content:     "// Copyright 2025\n// License\n\npackage main",
+			prefix:      "//",
+			expected:    2,
+			shouldError: false,
+		},
+		{
+			name:        "No comments",
+			content:     "package main\n\nfunc main() {}",
+			prefix:      "//",
+			expected:    0,
+			shouldError: false,
+		},
+		{
+			name:        "All comments",
+			content:     "// Line 1\n// Line 2\n// Line 3",
+			prefix:      "//",
+			expected:    3,
+			shouldError: false,
+		},
+		{
+			name:        "Unclosed C-style comment",
+			content:     "/*\n * Copyright 2025\n * No closing",
+			prefix:      "//",
+			expected:    0, // First line is /*, which doesn't match //, so content starts at line 0
+			shouldError: false,
+		},
+		{
+			name:        "C-style comment with closing on same line",
+			content:     "/* Copyright */\n\npackage main",
+			prefix:      "//",
+			expected:    0, // First line is not //, so content starts at line 0
+			shouldError: false,
+		},
+		{
+			name:        "C-style comment block with proper closing",
+			content:     "/*\n * Copyright 2025\n * License\n */\n\npackage main",
+			prefix:      "//",
+			expected:    5, // Line 3 has */, so returns 3+2=5
+			shouldError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testFile := filepath.Join(tmpDir, "test.go")
+			err := os.WriteFile(testFile, []byte(tt.content), 0644)
+			require.NoError(t, err, "Failed to create test file")
+
+			start, err := findContentStart(testFile, tt.prefix)
+			if tt.shouldError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, start, "Expected start=%d, got %d", tt.expected, start)
+			}
+		})
+	}
+}
+
+func TestFindContentStart_NonExistent(t *testing.T) {
+	_, err := findContentStart("/nonexistent/file.go", "//")
+	assert.Error(t, err, "Expected error for nonexistent file")
+}
+
+func TestAddLicenseToFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name            string
+		initialContent  string
+		licenseHeader   string
+		commentPrefix   string
+		expectedContent string
+	}{
+		{
+			name:            "Add to file without header",
+			initialContent:  "package main\n\nfunc main() {}",
+			licenseHeader:   "// Copyright 2025\n// License",
+			commentPrefix:   "//",
+			expectedContent: "// Copyright 2025\n// License\npackage main\n\nfunc main() {}\n",
+		},
+		{
+			name:            "Replace old header",
+			initialContent:  "// Old copyright\n// Old license\n\npackage main",
+			licenseHeader:   "// Copyright 2025\n// New license",
+			commentPrefix:   "//",
+			expectedContent: "// Copyright 2025\n// New license\n\npackage main\n",
+		},
+		{
+			name:            "File with C-style comment block",
+			initialContent:  "/*\n * Old copyright\n */\n\npackage main",
+			licenseHeader:   "// Copyright 2025\n// New license",
+			commentPrefix:   "//",
+			expectedContent: "// Copyright 2025\n// New license\npackage main\n",
+		},
+		{
+			name:            "File with only whitespace after header",
+			initialContent:  "// Old\n\n\n\npackage main",
+			licenseHeader:   "// New",
+			commentPrefix:   "//",
+			expectedContent: "// New\n\n\n\npackage main\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testFile := filepath.Join(tmpDir, "test.go")
+			err := os.WriteFile(testFile, []byte(tt.initialContent), 0644)
+			require.NoError(t, err, "Failed to create test file")
+
+			err = addLicenseToFile(testFile, tt.licenseHeader, tt.commentPrefix)
+			assert.NoError(t, err, "Unexpected error")
+
+			content, err := os.ReadFile(testFile)
+			require.NoError(t, err, "Failed to read result file")
+
+			result := string(content)
+			assert.Equal(t, tt.expectedContent, result)
+		})
+	}
+}
+
+func TestAddLicenseToFile_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "empty.go")
+	err := os.WriteFile(testFile, []byte(""), 0644)
+	require.NoError(t, err, "Failed to create test file")
+
+	licenseHeader := "// Copyright 2025"
+	err = addLicenseToFile(testFile, licenseHeader, "//")
+	assert.NoError(t, err, "Unexpected error")
+
+	content, _ := os.ReadFile(testFile)
+	assert.True(t, strings.HasPrefix(string(content), "// Copyright 2025"), "Empty file should have license added")
+}
+
+func TestAddLicenseToFile_ReadOnlyDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	readOnlyDir := filepath.Join(tmpDir, "readonly")
+	os.MkdirAll(readOnlyDir, 0755)
+
+	testFile := filepath.Join(readOnlyDir, "test.go")
+	err := os.WriteFile(testFile, []byte("package main"), 0644)
+	require.NoError(t, err, "Failed to create test file")
+
+	// Make directory read-only
+	os.Chmod(readOnlyDir, 0555)
+	defer os.Chmod(readOnlyDir, 0755) // Restore permissions for cleanup
+
+	licenseHeader := "// Copyright 2025"
+	err = addLicenseToFile(testFile, licenseHeader, "//")
+
+	// This is allowed on linux
+	assert.NoError(t, err)
+}
+
+func TestProcessFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "pkg"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "carmen"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, ".git"), 0755)
+
+	files := map[string]string{
+		filepath.Join(tmpDir, "test1.go"):          "package main\n\nfunc main() {}",
+		filepath.Join(tmpDir, "pkg", "test2.go"):   "package pkg\n\nfunc Test() {}",
+		filepath.Join(tmpDir, "carmen", "skip.go"): "package carmen", // Should be ignored
+		filepath.Join(tmpDir, ".git", "config"):    "config",         // Should be ignored
+		filepath.Join(tmpDir, "test.txt"):          "text file",      // Wrong extension
+	}
+
+	for path, content := range files {
+		err := os.WriteFile(path, []byte(content), 0644)
+		require.NoError(t, err, "Failed to create test file %s", path)
+	}
+
+	licenseHeader := "// Copyright 2025\n// Test License"
+
+	// Test with dryRun=false (should update files)
+	t.Run("Update files", func(t *testing.T) {
+		patterns := []string{"carmen/", "sonic/", "tosca/", "mock.go"}
+		results, err := processFiles(tmpDir, ".go", "//", licenseHeader, patterns, false)
+		assert.NoError(t, err, "Unexpected error")
+
+		// Count results
+		updatedCount := 0
+		for _, r := range results {
+			if r.Status == StatusUpdated {
+				updatedCount++
+			}
+		}
+		assert.Equal(t, 2, updatedCount, "Expected 2 files to be updated")
+
+		// Verify files were updated
+		content, _ := os.ReadFile(filepath.Join(tmpDir, "test1.go"))
+		assert.True(t, strings.HasPrefix(string(content), "// Copyright 2025"), "test1.go was not updated")
+
+		content, _ = os.ReadFile(filepath.Join(tmpDir, "pkg", "test2.go"))
+		assert.True(t, strings.HasPrefix(string(content), "// Copyright 2025"), "pkg/test2.go was not updated")
+
+		// Verify carmen directory was skipped
+		content, _ = os.ReadFile(filepath.Join(tmpDir, "carmen", "skip.go"))
+		assert.False(t, strings.HasPrefix(string(content), "// Copyright 2025"), "carmen/skip.go should not be updated (should be ignored)")
+	})
+
+	// Test with dryRun=true
+	t.Run("Dry-run mode", func(t *testing.T) {
+		tmpDir2 := t.TempDir()
+		testFile := filepath.Join(tmpDir2, "test.go")
+		err := os.WriteFile(testFile, []byte("package main"), 0644)
+		require.NoError(t, err, "Failed to create test file")
+
+		patterns := []string{"carmen/", "sonic/", "tosca/", "mock.go"}
+		results, err := processFiles(tmpDir2, ".go", "//", licenseHeader, patterns, true)
+		assert.NoError(t, err, "Unexpected error")
+
+		// Count missing files
+		missingCount := 0
+		for _, r := range results {
+			if r.Status == StatusMissing {
+				missingCount++
+			}
+		}
+		assert.Equal(t, 1, missingCount, "Expected 1 file to be missing header in dry-run")
+
+		// Verify file was NOT updated
+		content, _ := os.ReadFile(testFile)
+		assert.False(t, strings.HasPrefix(string(content), "// Copyright 2025"), "File should not be updated in dry-run mode")
+	})
+
+	// Test with files that already have correct headers
+	t.Run("Files with correct headers", func(t *testing.T) {
+		tmpDir3 := t.TempDir()
+		testFile := filepath.Join(tmpDir3, "correct.go")
+		correctContent := licenseHeader + "\n\npackage main\n\nfunc main() {}"
+		err := os.WriteFile(testFile, []byte(correctContent), 0644)
+		require.NoError(t, err, "Failed to create test file")
+
+		patterns := []string{"carmen/", "sonic/", "tosca/", "mock.go"}
+		results, err := processFiles(tmpDir3, ".go", "//", licenseHeader, patterns, false)
+		assert.NoError(t, err, "Unexpected error")
+
+		// All files should be correct
+		correctCount := 0
+		for _, r := range results {
+			if r.Status == StatusCorrect {
+				correctCount++
+			}
+		}
+		assert.Equal(t, 1, correctCount, "Expected 1 file with correct header")
+
+		// Verify file was not modified
+		content, _ := os.ReadFile(testFile)
+		assert.Equal(t, correctContent, string(content), "File with correct header should not be modified")
+	})
+}
+
+func TestProcessFiles_WalkError(t *testing.T) {
+	// Test with a directory that doesn't exist
+	patterns := []string{"carmen/", "sonic/", "tosca/", "mock.go"}
+	_, err := processFiles("/nonexistent/directory", ".go", "//", "// Header", patterns, false)
+	assert.Error(t, err, "Expected error for nonexistent directory")
+}
+
+func TestProcessFiles_CheckLicenseError(t *testing.T) {
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "subdir")
+	os.MkdirAll(subDir, 0755)
+
+	// Create a file that will be unreadable to cause a read error
+	testFile := filepath.Join(subDir, "test.go")
+	err := os.WriteFile(testFile, []byte("package main"), 0644)
+	require.NoError(t, err, "Failed to create test file")
+
+	// Make the file unreadable
+	os.Chmod(testFile, 0000)
+	defer os.Chmod(testFile, 0644) // Restore for cleanup
+
+	licenseHeader := "// Copyright 2025"
+	patterns := []string{"carmen/", "sonic/", "tosca/", "mock.go"}
+	_, err = processFiles(tmpDir, ".go", "//", licenseHeader, patterns, false)
+	assert.Error(t, err)
+}
+
+func TestUpdateCliAppCopyright(t *testing.T) {
+	tmpDir := t.TempDir()
+	cmdDir := filepath.Join(tmpDir, "cmd")
+	os.MkdirAll(cmdDir, 0755)
+
+	tests := []struct {
+		name         string
+		content      string
+		checkOnly    bool
+		expectedErr  int
+		shouldUpdate bool
+	}{
+		{
+			name: "Old copyright to update",
+			content: `package main
+import "github.com/urfave/cli/v2"
+var app = &cli.App{
+	Name: "test",
+	Copyright: "(c) 2022 Fantom Foundation",
+}`,
+			checkOnly:    false,
+			expectedErr:  0,
+			shouldUpdate: true,
+		},
+		{
+			name: "Check mode with old copyright",
+			content: `package main
+import "github.com/urfave/cli/v2"
+var app = &cli.App{
+	Name: "test",
+	Copyright: "(c) 2022 Fantom Foundation",
+}`,
+			checkOnly:    true,
+			expectedErr:  1,
+			shouldUpdate: false,
+		},
+		{
+			name: "No cli.App",
+			content: `package main
+func main() {}`,
+			checkOnly:    false,
+			expectedErr:  0,
+			shouldUpdate: false,
+		},
+		{
+			name: "Already updated copyright",
+			content: `package main
+import "github.com/urfave/cli/v2"
+var app = &cli.App{
+	Name: "test",
+	Copyright: "(c) 2025 Sonic Labs",
+}`,
+			checkOnly:    false,
+			expectedErr:  0,
+			shouldUpdate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testFile := filepath.Join(cmdDir, "test.go")
+			err := os.WriteFile(testFile, []byte(tt.content), 0644)
+			require.NoError(t, err, "Failed to create test file")
+
+			errorCount := updateCliAppCopyright(tmpDir, tt.checkOnly)
+			assert.Equal(t, tt.expectedErr, errorCount, "Expected %d errors, got %d", tt.expectedErr, errorCount)
+
+			content, _ := os.ReadFile(testFile)
+			contentStr := string(content)
+
+			if tt.shouldUpdate {
+				assert.Contains(t, contentStr, "Copyright: \"(c) 2025 Sonic Labs\"", "Copyright was not updated")
+			} else if tt.checkOnly && strings.Contains(tt.content, "cli.App") {
+				assert.NotContains(t, contentStr, "2025 Sonic Labs", "File should not be updated in check mode")
+			}
+
+			// Clean up for next test
+			os.Remove(testFile)
+		})
+	}
+}
+
+func TestUpdateCliAppCopyright_NoCmd(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Don't create cmd directory
+
+	errorCount := updateCliAppCopyright(tmpDir, false)
+	// Should return error when cmd directory doesn't exist
+	assert.Equal(t, 1, errorCount, "Expected 1 error when cmd directory doesn't exist")
+}
+
+func TestUpdateCliAppCopyright_MultipleFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	cmdDir := filepath.Join(tmpDir, "cmd")
+	os.MkdirAll(cmdDir, 0755)
+
+	// Create multiple files with different scenarios
+	files := map[string]string{
+		"app1.go": `package main
+import "github.com/urfave/cli/v2"
+var app = &cli.App{
+	Name: "app1",
+	Copyright: "(c) 2022 Fantom Foundation",
+}`,
+		"app2.go": `package main
+import "github.com/urfave/cli/v2"
+var app = &cli.App{
+	Name: "app2",
+	Copyright: "(c) 2025 Sonic Labs",
+}`,
+		"no_app.go": `package main
+func main() {}`,
+	}
+
+	for name, content := range files {
+		path := filepath.Join(cmdDir, name)
+		err := os.WriteFile(path, []byte(content), 0644)
+		require.NoError(t, err, "Failed to create test file %s", name)
+	}
+
+	// Test update mode
+	errorCount := updateCliAppCopyright(tmpDir, false)
+	assert.Equal(t, 0, errorCount, "Expected 0 errors in update mode")
+
+	// Verify app1.go was updated
+	content, _ := os.ReadFile(filepath.Join(cmdDir, "app1.go"))
+	assert.Contains(t, string(content), "2025 Sonic Labs", "app1.go should have been updated")
+
+	// Verify app2.go remained unchanged
+	content, _ = os.ReadFile(filepath.Join(cmdDir, "app2.go"))
+	assert.Contains(t, string(content), "2025 Sonic Labs", "app2.go should still have correct copyright")
+}
+
+func TestUpdateCliAppCopyright_ReadError(t *testing.T) {
+	tmpDir := t.TempDir()
+	cmdDir := filepath.Join(tmpDir, "cmd")
+	os.MkdirAll(cmdDir, 0755)
+
+	testFile := filepath.Join(cmdDir, "test.go")
+	content := `package main
+import "github.com/urfave/cli/v2"
+var app = &cli.App{
+	Name: "test",
+	Copyright: "(c) 2022 Fantom Foundation",
+}`
+	err := os.WriteFile(testFile, []byte(content), 0644)
+	require.NoError(t, err, "Failed to create test file")
+
+	// Make file unreadable
+	os.Chmod(testFile, 0000)
+	defer os.Chmod(testFile, 0644)
+
+	errCount := updateCliAppCopyright(tmpDir, false)
+	assert.Equal(t, 1, errCount, "Expected 1 error due to read failure")
+}
+
+func TestAddLicenseToFile_WithBlankLines(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.go")
+
+	// File with multiple blank lines at start
+	content := "\n\n\npackage main\n"
+	err := os.WriteFile(testFile, []byte(content), 0644)
+	require.NoError(t, err, "Failed to create test file")
+
+	licenseHeader := "// Copyright 2025"
+	err = addLicenseToFile(testFile, licenseHeader, "//")
+	assert.NoError(t, err, "Unexpected error")
+
+	result, _ := os.ReadFile(testFile)
+	assert.True(t, strings.HasPrefix(string(result), "// Copyright 2025"), "License should be added before blank lines")
+}
+
+func TestAddLicenseToFile_OnlyComments(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.go")
+
+	// File with only comments
+	content := "// Old comment\n// Another comment"
+	err := os.WriteFile(testFile, []byte(content), 0644)
+	require.NoError(t, err, "Failed to create test file")
+
+	licenseHeader := "// Copyright 2025"
+	err = addLicenseToFile(testFile, licenseHeader, "//")
+	assert.NoError(t, err, "Unexpected error")
+
+	result, _ := os.ReadFile(testFile)
+	expected := "// Copyright 2025\n"
+	assert.Equal(t, expected, string(result))
+}
+
+func TestAddLicenseToFile_LongFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "long.go")
+
+	// Create a file with many lines
+	var builder strings.Builder
+	for i := 0; i < 100; i++ {
+		builder.WriteString(fmt.Sprintf("// Line %d\n", i))
+	}
+	builder.WriteString("\npackage main\n")
+
+	err := os.WriteFile(testFile, []byte(builder.String()), 0644)
+	require.NoError(t, err, "Failed to create test file")
+
+	licenseHeader := "// Copyright 2025\n// License"
+	err = addLicenseToFile(testFile, licenseHeader, "//")
+	assert.NoError(t, err, "Unexpected error")
+
+	result, _ := os.ReadFile(testFile)
+	assert.True(t, strings.HasPrefix(string(result), "// Copyright 2025"), "License should be added to long file")
+}


### PR DESCRIPTION
## Description

Current license check script run very slow on my device (1-2 minutes), I think it is better to implement in go instead.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (changes that do NOT affect functionality)
- [ ] Adds or updates testing
- [ ] This change requires a documentation update
