### PR TITLE
Change default substate encoding to Protobuf

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
         ARCHIVE = '--archive --archive-variant s5'
         PRIME = '--update-buffer-size 4000'
         VM = '--vm-impl lfvm'
-        AIDADB = '--aida-db /mnt/substate-opera-mainnet/aida-db'
+        AIDADB = '--aida-db /mnt/substate-opera-mainnet/aida-db --substate-encoding rlp'
         TMPDB = '--db-tmp /mnt/tmp-disk'
         DBSRC = '/mnt/tmp-disk/state_db_carmen_go-file_${TOBLOCK}'
         PROFILE = '--cpu-profile cpu-profile.dat --memory-profile mem-profile.dat --memory-breakdown'
@@ -248,7 +248,7 @@ pipeline {
                     steps {
                         sh "make clean"
                         sh "rm -rf *.dat ${TRACEDIR}"
-                        sh "rm -rf /var/opera/Aida/dbtmpjenkins/state_db_carmen_go-file_${TOBLOCK}"
+                        sh "rm -rf /mnt/tmp-disk/state_db_carmen_go-file_${TOBLOCK}"
                     }
                 }
             }

--- a/cmd/aida-sdb/trace/trace.go
+++ b/cmd/aida-sdb/trace/trace.go
@@ -62,6 +62,7 @@ var TraceReplayCommand = cli.Command{
 		//&utils.ValidateFlag,
 		//&utils.ValidateTxStateFlag,
 		&utils.AidaDbFlag,
+		&utils.SubstateEncodingFlag,
 		&logger.LogLevelFlag,
 	},
 	Description: `
@@ -99,6 +100,7 @@ var TraceReplaySubstateCommand = cli.Command{
 		//&utils.ValidateFlag,
 		//&utils.ValidateTxStateFlag,
 		&utils.AidaDbFlag,
+		&utils.SubstateEncodingFlag,
 		&logger.LogLevelFlag,
 	},
 	Description: `

--- a/cmd/aida-stochastic-sdb/stochastic/record.go
+++ b/cmd/aida-stochastic-sdb/stochastic/record.go
@@ -47,6 +47,7 @@ var StochasticRecordCommand = cli.Command{
 		&utils.ChainIDFlag,
 		&utils.AidaDbFlag,
 		&utils.CacheFlag,
+		&utils.SubstateEncodingFlag,
 	},
 	Description: `
 The stochastic record command requires two arguments:

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -222,7 +222,7 @@ var (
 	SubstateEncodingFlag = cli.StringFlag{
 		Name:  "substate-encoding",
 		Usage: "select encoding when reading substate from disk: rlp (default) or protobuf",
-		Value: "rlp",
+		Value: "protobuf",
 	}
 	TraceFlag = cli.BoolFlag{
 		Name:  "trace",


### PR DESCRIPTION
## Description

The majority of our dataset is not using protobuf encoding. This PR switch the default value from `rlp` to `protobuf`

## Type of change

Please delete options that are not relevant.

- [ ] Refactoring (changes that do NOT affect functionality)