### PR TITLE
Update required go version to 1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Aida is a block-processing testing infrastructure for EVM-compatible chains.
 
 ## Building the source
 
-Building `aida` requires a Go (version 1.21 or later), plus submodules require either Docker or C compiler with bazel 5.2.3.
+Building `aida` requires a Go (version 1.25 or later), plus submodules require either Docker or C compiler with bazel 5.2.3.
 Once the dependencies are installed, run
 
 ```shell

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/0xsoniclabs/aida
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.25.0
 
 require (
 	github.com/0xsoniclabs/carmen/go v0.0.0-20251014092906-75df60dc78cb


### PR DESCRIPTION
## Description

This PR update required go version to 1.25. This is a requirement from upstream projects.

## Type of change

Please delete options that are not relevant.

- [ ] Refactoring (changes that do NOT affect functionality)
