### PR TITLE
Fix typo in context test

### DIFF
--- a/profile/blockprofile/context_test.go
+++ b/profile/blockprofile/context_test.go
@@ -403,7 +403,7 @@ func TestRecordTransaction(t *testing.T) {
 		t.Errorf("invalid length of ctx.gasTransactions")
 	}
 
-	if len(ctx.txAddresses) == 2 && len(ctx.txAddresses[0]) == 3 && len(ctx.txAddresses[0]) == 3 {
+	if len(ctx.txAddresses) == 2 && len(ctx.txAddresses[0]) == 3 && len(ctx.txAddresses[1]) == 3 {
 		if !checkAddr(ctx.txAddresses[0]) {
 			t.Errorf("Unexpected addresses in first transaction")
 		}


### PR DESCRIPTION
## Description

Fix typo in context test which causes lint error. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
