### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -1,5 +1,8 @@
 name: Documentation
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:
@@ -18,4 +21,3 @@ jobs:
           path: "docs"
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-


### PR DESCRIPTION
Potential fix for [https://github.com/0xsoniclabs/aida/security/code-scanning/2](https://github.com/0xsoniclabs/aida/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only uploads documentation to a wiki using a personal access token, the `GITHUB_TOKEN` does not need any write permissions. We can set the `permissions` block at the root level of the workflow to apply to all jobs, specifying `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
