### PR TITLE
Force rlp encoding for updatesets and deletion db

### DIFF
--- a/cmd/util-db/clone/clone_test.go
+++ b/cmd/util-db/clone/clone_test.go
@@ -107,7 +107,7 @@ func testClone(t *testing.T, aidaDb db.SubstateDB, cloningType utils.AidaDbType,
 
 	if dbc == "" || dbc == "all" || dbc == "update" {
 		t.Run("UpdateSets", func(t *testing.T) {
-			udb, err := db.MakeDefaultUpdateDBFromBaseDB(cloneDb)
+			udb, err := db.MakeDefaultUpdateDBFromBaseDBWithEncoding(cloneDb, db.RLPEncodingSchema)
 			assert.NoError(t, err)
 			updateSetCount := 0
 			updateSetIter := udb.NewUpdateSetIterator(cfg.First, cfg.Last)

--- a/cmd/util-db/info/info_test.go
+++ b/cmd/util-db/info/info_test.go
@@ -872,7 +872,7 @@ func generateTestAidaDb(t *testing.T) string {
 	}
 
 	// insert update
-	udb, err := db.MakeDefaultUpdateDBFromBaseDB(aidaDb)
+	udb, err := db.MakeDefaultUpdateDBFromBaseDBWithEncoding(aidaDb, db.RLPEncodingSchema)
 	assert.NoError(t, err)
 	err = udb.PutUpdateSet(&us, us.DeletedAccounts)
 	assert.NoError(t, err)

--- a/cmd/util-db/info/range.go
+++ b/cmd/util-db/info/range.go
@@ -83,7 +83,7 @@ func printRange(cfg *utils.Config, log logger.Logger) error {
 
 	// print update range
 	if dbComponent == dbcomponent.Update || dbComponent == dbcomponent.All {
-		udb, err := db.MakeDefaultUpdateDBFromBaseDB(baseDb)
+		udb, err := db.MakeDefaultUpdateDBFromBaseDBWithEncoding(baseDb, db.RLPEncodingSchema)
 		if err != nil {
 			return err
 		}

--- a/cmd/util-db/info/range.go
+++ b/cmd/util-db/info/range.go
@@ -97,7 +97,7 @@ func printRange(cfg *utils.Config, log logger.Logger) error {
 
 	// print deleted range
 	if dbComponent == dbcomponent.Delete || dbComponent == dbcomponent.All {
-		ddb, err := db.MakeDefaultDestroyedAccountDBFromBaseDB(baseDb)
+		ddb, err := db.MakeDefaultDestroyedAccountDBFromBaseDBWithEncoding(baseDb, db.RLPEncodingSchema)
 		if err != nil {
 			return err
 		}

--- a/cmd/util-updateset/updateset/stats.go
+++ b/cmd/util-updateset/updateset/stats.go
@@ -68,5 +68,9 @@ func reportUpdateSetStats(ctx *cli.Context) error {
 		}
 		fmt.Printf("%v\n", storage)
 	}
+
+	if iter.Error() != nil {
+		err = errors.Join(err, fmt.Errorf("failed to iterate update-set: %v", iter.Error()))
+	}
 	return err
 }

--- a/executor/extension/primer/primer_test.go
+++ b/executor/extension/primer/primer_test.go
@@ -74,10 +74,18 @@ func TestStateDbPrimerExtension_PrimingDoesTriggerForExistingStateDb(t *testing.
 	kv.PutU(db.SubstateDBKey(input.Block, input.Transaction), encoded)
 	iter := iterator.NewArrayIterator(kv)
 
+	kvUpdate := &testutil.KeyValue{}
+	iterUpdate := iterator.NewArrayIterator(kvUpdate)
+
 	// start priming
 	mockAidaDb.EXPECT().GetBackend().Return(mockAdapter).AnyTimes()
 	mockAidaDb.EXPECT().GetSubstateEncoding().Return(db.DefaultEncodingSchema).Times(3)
-	mockAdapter.EXPECT().NewIterator(gomock.Any(), gomock.Any()).Return(iter).AnyTimes()
+	// substateIterator
+	mockAdapter.EXPECT().NewIterator(gomock.Any(), gomock.Any()).Return(iter).Times(1)
+	// updatesetIterator
+	mockAdapter.EXPECT().NewIterator(gomock.Any(), gomock.Any()).Return(iterUpdate).Times(1)
+	// deleteIterator
+	mockAdapter.EXPECT().NewIterator(gomock.Any(), gomock.Any()).Return(iter).Times(1)
 	// loadExistingAccountsIntoCache is executed only if an existing db is used
 	mockStateDb.EXPECT().BeginBlock(gomock.Any()).Return(nil)
 	mockStateDb.EXPECT().BeginTransaction(gomock.Any()).Return(nil)

--- a/prime/primer.go
+++ b/prime/primer.go
@@ -55,7 +55,7 @@ func newPrimer(cfg *utils.Config, state state.StateDB, aidaDb db.BaseDB, log log
 		if err != nil {
 			return nil, err
 		}
-		p.ddb, err = db.MakeDefaultDestroyedAccountDBFromBaseDB(aidaDb)
+		p.ddb, err = db.MakeDefaultDestroyedAccountDBFromBaseDBWithEncoding(aidaDb, db.RLPEncodingSchema)
 		if err != nil {
 			return nil, err
 		}

--- a/prime/primer.go
+++ b/prime/primer.go
@@ -51,7 +51,7 @@ func newPrimer(cfg *utils.Config, state state.StateDB, aidaDb db.BaseDB, log log
 		if err != nil {
 			return nil, err
 		}
-		p.udb, err = db.MakeDefaultUpdateDBFromBaseDB(aidaDb)
+		p.udb, err = db.MakeDefaultUpdateDBFromBaseDBWithEncoding(aidaDb, db.RLPEncodingSchema)
 		if err != nil {
 			return nil, err
 		}
@@ -164,6 +164,10 @@ func (p *primer) mayPrimeFromUpdateSet() error {
 			incrementalSize/1_000_000)
 		// advance next primable block after merge update set
 		p.block++
+	}
+
+	if updateIter.Error() != nil {
+		return fmt.Errorf("cannot iterate update-set; %v", updateIter.Error())
 	}
 
 	if len(update) > 0 {

--- a/prime/worldstate_update_test.go
+++ b/prime/worldstate_update_test.go
@@ -109,7 +109,7 @@ func TestStatedb_DeleteDestroyedAccountsFromWorldState(t *testing.T) {
 			}
 
 			// Creating new destroyed accounts DB
-			daDB, err := db.MakeDefaultDestroyedAccountDBFromBaseDB(daBackend)
+			daDB, err := db.MakeDefaultDestroyedAccountDBFromBaseDBWithEncoding(daBackend, db.RLPEncodingSchema)
 			assert.NoError(t, err)
 
 			// Storing two picked accounts from destroyedAccounts slice to destroyed accounts DB
@@ -163,7 +163,7 @@ func TestStatedb_DeleteDestroyedAccountsFromStateDB(t *testing.T) {
 			}
 
 			// Creating new destroyed accounts DB
-			ddb, err := db.MakeDefaultDestroyedAccountDBFromBaseDB(aidaDb)
+			ddb, err := db.MakeDefaultDestroyedAccountDBFromBaseDBWithEncoding(aidaDb, db.RLPEncodingSchema)
 			assert.NoError(t, err)
 
 			// Storing two picked accounts from destroyedAccounts slice to destroyed accounts DB

--- a/utildb/table_hash.go
+++ b/utildb/table_hash.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -224,7 +225,7 @@ func GetUpdateDbHash(cfg *utils.Config, base db.BaseDB, log logger.Logger) ([]by
 	feeder := func(feederChan chan any, errChan chan error) {
 		defer close(feederChan)
 
-		udb, err := db.MakeDefaultUpdateDBFromBaseDB(base)
+		udb, err := db.MakeDefaultUpdateDBFromBaseDBWithEncoding(base, db.RLPEncodingSchema)
 		if err != nil {
 			errChan <- err
 			return
@@ -246,6 +247,10 @@ func GetUpdateDbHash(cfg *utils.Config, base db.BaseDB, log logger.Logger) ([]by
 				return
 			case feederChan <- value:
 			}
+		}
+
+		if iter.Error() != nil {
+			errChan <- fmt.Errorf("failed to iterate update-set: %v", iter.Error())
 		}
 	}
 	return parallelHashComputing(feeder)

--- a/utildb/table_hash.go
+++ b/utildb/table_hash.go
@@ -164,7 +164,7 @@ func GetDeletionHash(
 	ticker := time.NewTicker(progressLoggerFrequency)
 	defer ticker.Stop()
 
-	dDb, err := db.MakeDefaultDestroyedAccountDBFromBaseDB(aidaDb)
+	dDb, err := db.MakeDefaultDestroyedAccountDBFromBaseDBWithEncoding(aidaDb, db.RLPEncodingSchema)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/utildb/table_hash_test.go
+++ b/utildb/table_hash_test.go
@@ -502,7 +502,7 @@ func fillFakeAidaDb(t *testing.T, aidaDb db.BaseDB) (int, int, int, int, int, in
 		}
 	}
 
-	ddb, err := db.MakeDefaultDestroyedAccountDBFromBaseDB(aidaDb)
+	ddb, err := db.MakeDefaultDestroyedAccountDBFromBaseDBWithEncoding(aidaDb, db.RLPEncodingSchema)
 	assert.NoError(t, err)
 
 	// Generate random number between 6-10
@@ -515,7 +515,7 @@ func fillFakeAidaDb(t *testing.T, aidaDb db.BaseDB) (int, int, int, int, int, in
 		}
 	}
 
-	udb, err := db.MakeDefaultUpdateDBFromBaseDBWithEncoding(aidaDb)
+	udb, err := db.MakeDefaultUpdateDBFromBaseDBWithEncoding(aidaDb, db.RLPEncodingSchema)
 	assert.NoError(t, err)
 
 	// Generate random number between 11-15

--- a/utildb/table_hash_test.go
+++ b/utildb/table_hash_test.go
@@ -515,7 +515,7 @@ func fillFakeAidaDb(t *testing.T, aidaDb db.BaseDB) (int, int, int, int, int, in
 		}
 	}
 
-	udb, err := db.MakeDefaultUpdateDBFromBaseDB(aidaDb)
+	udb, err := db.MakeDefaultUpdateDBFromBaseDBWithEncoding(aidaDb)
 	assert.NoError(t, err)
 
 	// Generate random number between 11-15

--- a/utildb/utils.go
+++ b/utildb/utils.go
@@ -256,7 +256,7 @@ func GenerateTestAidaDb(t *testing.T) db.BaseDB {
 		require.NoError(t, err)
 	}
 
-	udb, err := db.MakeDefaultUpdateDBFromBaseDB(database)
+	udb, err := db.MakeDefaultUpdateDBFromBaseDBWithEncoding(database, db.RLPEncodingSchema)
 	require.NoError(t, err)
 	// write update sets to the database
 	for i := 1; i <= 10; i++ {


### PR DESCRIPTION
## Description

Currently all of our updateset and deletion db records are in RLP and new Substate version was changed to be by default in PB. This PR temporarily fixes this inconsistency.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
