### PR TITLE
update substate; change default encoding of updatedb and deletiondb

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,7 @@ pipeline {
                 stage('Lint') {
                     steps {
                         sh "git submodule update --init --recursive"
+                        sh "go mod tidy"
                         sh "make install-dev-tools"
                         sh "make check"
                     }

--- a/executor/extension/primer/primer_test.go
+++ b/executor/extension/primer/primer_test.go
@@ -76,7 +76,7 @@ func TestStateDbPrimerExtension_PrimingDoesTriggerForExistingStateDb(t *testing.
 
 	// start priming
 	mockAidaDb.EXPECT().GetBackend().Return(mockAdapter).AnyTimes()
-	mockAidaDb.EXPECT().GetSubstateEncoding().Return(db.DefaultEncodingSchema).Times(3)
+	mockAidaDb.EXPECT().GetSubstateEncoding().Return(db.DefaultEncodingSchema).Times(1)
 	mockAdapter.EXPECT().NewIterator(gomock.Any(), gomock.Any()).Return(iter).AnyTimes()
 	// loadExistingAccountsIntoCache is executed only if an existing db is used
 	mockStateDb.EXPECT().BeginBlock(gomock.Any()).Return(nil)

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 )
 
 require (
+	github.com/0xsoniclabs/tracy v0.0.0-20251027125423-00a5ab7968fb // indirect
 	github.com/DataDog/zstd v1.5.6 // indirect
 	github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e // indirect
 	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/0xsoniclabs/carmen/go v0.0.0-20251024091706-e1c5a32d4310
 	github.com/0xsoniclabs/sonic v0.0.0-20250729080702-e82930ba5cad
-	github.com/0xsoniclabs/substate v0.0.0-20251118214143-ef0b309b9e24
+	github.com/0xsoniclabs/substate v0.0.0-20260210033457-fde3f1bee6ca
 	github.com/0xsoniclabs/tosca v0.0.0-20260223084600-d2ea7c5c23ff
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Fantom-foundation/Norma v0.0.0-20240422103552-42e37352b2f4
@@ -36,7 +36,6 @@ require (
 )
 
 require (
-	github.com/0xsoniclabs/tracy v0.0.0-20251027125423-00a5ab7968fb // indirect
 	github.com/DataDog/zstd v1.5.6 // indirect
 	github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e // indirect
 	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/0xsoniclabs/go-ethereum v0.0.0-20260220094642-cad493048916 h1:aD8IqUU
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260220094642-cad493048916/go.mod h1:TlbbIilsvHx5hhDGx0sdKnAPRv0S2cp1XRKr4L21ioc=
 github.com/0xsoniclabs/substate v0.0.0-20260210033457-fde3f1bee6ca h1:kLjIK3fQN8HT3FY07kaQdY7dGAjaM1QktOJUIVvdqKA=
 github.com/0xsoniclabs/substate v0.0.0-20260210033457-fde3f1bee6ca/go.mod h1:k3uJXkU8P6JAMjvPPnLb32iw6UkZoTYUNVy9rFBaGFM=
+github.com/0xsoniclabs/tracy v0.0.0-20251027125423-00a5ab7968fb h1:mb6rPN+DpA/N2QWrQrLQEG2uzrYgy061PPauifstXNM=
+github.com/0xsoniclabs/tracy v0.0.0-20251027125423-00a5ab7968fb/go.mod h1:KUPXHA9bbj/EFrzSd/7i4XIh2SOxDljWCRBmpOpAVxE=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
@@ -65,6 +67,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/siphash v1.2.3 h1:QXwFc8cFOR2dSa/gE6o/HokBMWtLUaNDVd+22aKHeEA=
 github.com/dchest/siphash v1.2.3/go.mod h1:0NvQU092bT0ipiFN++/rXm69QG9tVxLAlQHIXMPAkHc=
+github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsPppp4=
+github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/deckarep/golang-set/v2 v2.6.0 h1:XfcQbWM1LlMB8BsJ8N9vW5ehnnPVIw0je80NsVHagjM=
 github.com/deckarep/golang-set/v2 v2.6.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260220094642-cad493048916 h1:aD8IqUUk0QTh21xQuGAn2IQmnUQTfwbszSkNuWoEGvQ=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260220094642-cad493048916/go.mod h1:TlbbIilsvHx5hhDGx0sdKnAPRv0S2cp1XRKr4L21ioc=
-github.com/0xsoniclabs/substate v0.0.0-20251118214143-ef0b309b9e24 h1:/3+j3u3IEzGDec6EtoaQOIb4BjlBIUYk9OltUUMGUw4=
-github.com/0xsoniclabs/substate v0.0.0-20251118214143-ef0b309b9e24/go.mod h1:k3uJXkU8P6JAMjvPPnLb32iw6UkZoTYUNVy9rFBaGFM=
-github.com/0xsoniclabs/tracy v0.0.0-20251027125423-00a5ab7968fb h1:mb6rPN+DpA/N2QWrQrLQEG2uzrYgy061PPauifstXNM=
-github.com/0xsoniclabs/tracy v0.0.0-20251027125423-00a5ab7968fb/go.mod h1:KUPXHA9bbj/EFrzSd/7i4XIh2SOxDljWCRBmpOpAVxE=
+github.com/0xsoniclabs/substate v0.0.0-20260210033457-fde3f1bee6ca h1:kLjIK3fQN8HT3FY07kaQdY7dGAjaM1QktOJUIVvdqKA=
+github.com/0xsoniclabs/substate v0.0.0-20260210033457-fde3f1bee6ca/go.mod h1:k3uJXkU8P6JAMjvPPnLb32iw6UkZoTYUNVy9rFBaGFM=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
@@ -67,8 +65,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/siphash v1.2.3 h1:QXwFc8cFOR2dSa/gE6o/HokBMWtLUaNDVd+22aKHeEA=
 github.com/dchest/siphash v1.2.3/go.mod h1:0NvQU092bT0ipiFN++/rXm69QG9tVxLAlQHIXMPAkHc=
-github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsPppp4=
-github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/deckarep/golang-set/v2 v2.6.0 h1:XfcQbWM1LlMB8BsJ8N9vW5ehnnPVIw0je80NsVHagjM=
 github.com/deckarep/golang-set/v2 v2.6.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=

--- a/prime/primer_test.go
+++ b/prime/primer_test.go
@@ -51,7 +51,7 @@ func TestPrime_NewPrimer(t *testing.T) {
 
 	mockAidaDb.EXPECT().GetBackend().Return(mockAdapter).AnyTimes()
 	mockAdapter.EXPECT().NewIterator(gomock.Any(), gomock.Any()).Return(iter).AnyTimes()
-	mockAidaDb.EXPECT().GetSubstateEncoding().Return(db.DefaultEncodingSchema).Times(3)
+	mockAidaDb.EXPECT().GetSubstateEncoding().Return(db.DefaultEncodingSchema).Times(1)
 
 	p, err := newPrimer(cfg, mockStateDb, mockAidaDb, log)
 


### PR DESCRIPTION
## Description

This change fixes an issue where wrong encoding is used for updatedb and substatedb. The fix is introduced in substate repo. This PR brings the fix forward to aida repo.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)