### PR TITLE
Fix flaky TestArchiveInquirer_RunProgressReport

### DIFF
--- a/executor/extension/statedb/archive_inquirer_test.go
+++ b/executor/extension/statedb/archive_inquirer_test.go
@@ -334,11 +334,6 @@ func TestArchiveInquirer_RunProgressReport(t *testing.T) {
 	// We capture the arguments to verify them after the goroutine finishes.
 	mockLog.EXPECT().Infof(formatString, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(format string, args ...interface{}) {
-			// Signal that the log was called, but don't block if it's already signaled.
-			select {
-			case called <- struct{}{}:
-			default:
-			}
 			if len(args) == 4 {
 				var ok bool
 				_, ok = args[0].(int)
@@ -359,6 +354,11 @@ func TestArchiveInquirer_RunProgressReport(t *testing.T) {
 				}
 			} else {
 				t.Logf("Infof called with unexpected number of arguments: %d", len(args))
+			}
+			// Signal that the log was called, but don't block if it's already signaled.
+			select {
+			case called <- struct{}{}:
+			default:
 			}
 		}).MinTimes(1)
 

--- a/executor/extension/statedb/archive_inquirer_test.go
+++ b/executor/extension/statedb/archive_inquirer_test.go
@@ -310,11 +310,12 @@ func TestArchiveInquirer_RunProgressReport(t *testing.T) {
 	defer ctrl.Finish()
 	mockLog := logger.NewMockLogger(ctrl)
 
-	duration := 500 * time.Millisecond
+	called := make(chan struct{}, 1)
+
 	inquirer := &archiveInquirer{
 		log:            mockLog,
 		finished:       utils.MakeEvent(),
-		tickerDuration: duration,
+		tickerDuration: 100 * time.Millisecond,
 	}
 
 	initialTxCount := uint64(20)
@@ -333,6 +334,11 @@ func TestArchiveInquirer_RunProgressReport(t *testing.T) {
 	// We capture the arguments to verify them after the goroutine finishes.
 	mockLog.EXPECT().Infof(formatString, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(format string, args ...interface{}) {
+			// Signal that the log was called, but don't block if it's already signaled.
+			select {
+			case called <- struct{}{}:
+			default:
+			}
 			if len(args) == 4 {
 				var ok bool
 				_, ok = args[0].(int)
@@ -358,7 +364,12 @@ func TestArchiveInquirer_RunProgressReport(t *testing.T) {
 
 	go inquirer.runProgressReport()
 
-	time.Sleep(1 * time.Second)
+	// Wait for the log to be called, which indicates that runProgressReport has executed at least once.
+	select {
+	case <-called:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for progress report")
+	}
 
 	inquirer.finished.Signal()
 	inquirer.done.Wait() // Wait for runProgressReport to complete

--- a/executor/extension/statedb/archive_inquirer_test.go
+++ b/executor/extension/statedb/archive_inquirer_test.go
@@ -310,7 +310,7 @@ func TestArchiveInquirer_RunProgressReport(t *testing.T) {
 	defer ctrl.Finish()
 	mockLog := logger.NewMockLogger(ctrl)
 
-	duration := 1 * time.Second
+	duration := 500 * time.Millisecond
 	inquirer := &archiveInquirer{
 		log:            mockLog,
 		finished:       utils.MakeEvent(),
@@ -358,7 +358,7 @@ func TestArchiveInquirer_RunProgressReport(t *testing.T) {
 
 	go inquirer.runProgressReport()
 
-	time.Sleep(duration)
+	time.Sleep(1 * time.Second)
 
 	inquirer.finished.Signal()
 	inquirer.done.Wait() // Wait for runProgressReport to complete


### PR DESCRIPTION
## Description

The test used a 1s ticker with a 1s sleep, creating a race between the ticker and the finished signal. This change reduces the ticker to 500ms so the ticker is guarantee to fire before shutdown.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (changes that do NOT affect functionality)
- [x] Adds or updates testing
- [ ] This change requires a documentation update
