### PR TITLE
Introduce new flag for enable exception updater extension

### DIFF
--- a/cmd/aida-vm-sdb/main.go
+++ b/cmd/aida-vm-sdb/main.go
@@ -94,6 +94,7 @@ var RunSubstateCmd = cli.Command{
 		&utils.ProfileIntervalFlag,
 		&utils.ProfileDBFlag,
 		&utils.ProfileBlocksFlag,
+		&utils.EnableExceptionUpdaterFlag,
 
 		// RegisterRun
 		&utils.RegisterRunFlag,

--- a/cmd/aida-vm/main.go
+++ b/cmd/aida-vm/main.go
@@ -58,6 +58,7 @@ var runVmApp = &cli.App{
 		&utils.DeltaLoggingFlag,
 		&utils.CacheFlag,
 		&utils.SubstateEncodingFlag,
+		&utils.EnableExceptionUpdaterFlag,
 	},
 }
 

--- a/executor/extension/validator/ethereum_post_transaction_updater.go
+++ b/executor/extension/validator/ethereum_post_transaction_updater.go
@@ -69,6 +69,10 @@ func MakeEthereumDbPostTransactionUpdater(cfg *utils.Config) executor.Extension[
 }
 
 func makeEthereumDbPostTransactionUpdater(cfg *utils.Config, log logger.Logger) executor.Extension[txcontext.TxContext] {
+	if !cfg.EnableExceptionUpdater {
+		return extension.NilExtension[txcontext.TxContext]{}
+	}
+
 	if cfg.VmImpl != "lfvm" {
 		return extension.NilExtension[txcontext.TxContext]{}
 	}

--- a/executor/extension/validator/ethereum_post_transaction_updater_test.go
+++ b/executor/extension/validator/ethereum_post_transaction_updater_test.go
@@ -56,6 +56,7 @@ func TestEthereumPostTransactionUpdater_SkippedExtensionBecauseOfWrongVmImplOrWr
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &utils.Config{}
+			cfg.EnableExceptionUpdater = true
 			cfg.VmImpl = tt.vmImpl
 			cfg.ChainID = tt.chainId
 
@@ -83,6 +84,7 @@ func TestEthereumPostTransactionUpdater_SkippedExtensionBecauseOfWrongVmImplOrWr
 
 func TestEthereumPostTransactionUpdater_NonExceptionBlockDoesntGetOverwritten(t *testing.T) {
 	cfg := &utils.Config{}
+	cfg.EnableExceptionUpdater = true
 	cfg.VmImpl = "lfvm"
 	cfg.ChainID = utils.EthereumChainID
 
@@ -111,6 +113,7 @@ func TestEthereumPostTransactionUpdater_NonExceptionBlockDoesntGetOverwritten(t 
 
 func TestEthereumPostTransactionUpdater_ExceptionBlockGetsOverwritten(t *testing.T) {
 	cfg := &utils.Config{}
+	cfg.EnableExceptionUpdater = true
 	cfg.VmImpl = "lfvm"
 	cfg.ChainID = utils.EthereumChainID
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -316,6 +316,7 @@ type Config struct {
 	DeleteSourceDbs          bool                      // delete source databases
 	DeletionDb               string                    // directory of deleted account database
 	DiagnosticServer         int64                     // if not zero, the port used for hosting a HTTP server for performance diagnostics
+	EnableExceptionUpdater   bool                      // enables post transaction updater for blocks with code-size too large
 	ErrorLogging             string                    // if defined, error logging to file is enabled
 	EthTestType              EthTestType               // which geth test are we running
 	EvmImpl                  string                    // processor implementation

--- a/utils/default_config.go
+++ b/utils/default_config.go
@@ -83,6 +83,7 @@ func createConfigFromFlags(ctx *cli.Context) *Config {
 		OverwriteRunId:           getFlagValue(ctx, OverwriteRunIdFlag).(string),
 		PrimeRandom:              getFlagValue(ctx, RandomizePrimingFlag).(bool),
 		PrimeThreshold:           getFlagValue(ctx, PrimeThresholdFlag).(int),
+		EnableExceptionUpdater:   getFlagValue(ctx, EnableExceptionUpdaterFlag).(bool),
 		Profile:                  getFlagValue(ctx, ProfileFlag).(bool),
 		ProfileBlocks:            getFlagValue(ctx, ProfileBlocksFlag).(bool),
 		ProfileDB:                getFlagValue(ctx, ProfileDBFlag).(string),

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -454,6 +454,10 @@ var (
 		Name:  "validate-state-hash",
 		Usage: "enables state hash validation",
 	}
+	EnableExceptionUpdaterFlag = cli.BoolFlag{
+		Name:  "enable-exception-updater",
+		Usage: "enables post transaction updater for blocks with code-size too large (pre-Osaka)",
+	}
 	ProfileBlocksFlag = cli.BoolFlag{
 		Name:  "profile-blocks",
 		Usage: "enables block profiling",


### PR DESCRIPTION
## Description

With this change, exception updater are disabled by default. The tools expect that VM can handle large-code size according to fork rules. The flag is introduced to keep legacy feature.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Adds or updates testing

