### PR TITLE
Fix skipped parent hash updates

### DIFF
--- a/executor/extension/statedb/parent_block_hash_processor.go
+++ b/executor/extension/statedb/parent_block_hash_processor.go
@@ -50,6 +50,7 @@ type parentBlockHashProcessor struct {
 	hashProvider db.HashProvider
 	processor    iEvmProcessor
 	cfg          *utils.Config
+	lastProcessedBlock uint64 // Substate may skip blocks, so we need to track the last processed block to fill the gaps
 	extension.NilExtension[txcontext.TxContext]
 }
 
@@ -62,6 +63,8 @@ type iEvmProcessor interface {
 // evmProcessor is a wrapper around evmcore.ProcessParentBlockHash.
 type evmProcessor struct{}
 
+// ProcessParentBlockHash saves prevHash in the blockchain by calling the history storage contract.
+// Copied from sonic codebase.
 func (p evmProcessor) ProcessParentBlockHash(prevHash common.Hash, evm *vm.EVM, state state.StateDB) error {
 	msg := &core.Message{
 		From:      params.SystemAddress,
@@ -85,14 +88,24 @@ func (p evmProcessor) ProcessParentBlockHash(prevHash common.Hash, evm *vm.EVM, 
 
 func (p *parentBlockHashProcessor) PreRun(_ executor.State[txcontext.TxContext], ctx *executor.Context) error {
 	p.hashProvider = db.MakeHashProvider(ctx.AidaDb)
+	// initialized the last processed block
+	if p.cfg.First > 0 {
+		p.lastProcessedBlock = utils.KeywordBlocks[p.cfg.ChainID]["first"]
+	}
 	return nil
 }
 
-// PreBlock processes parent block hash.
+// PreBlock processes parent block hash. It loops from the previous processed
+// block to the current block to fill any gaps caused by skipped blocks in substate.
 func (p *parentBlockHashProcessor) PreBlock(state executor.State[txcontext.TxContext], ctx *executor.Context) error {
+	defer func() {
+		p.lastProcessedBlock = uint64(state.Block)
+	}()
+
 	// We are saving historic block hashes, first block must be skipped because
 	// there is no history at this point
-	if uint64(state.Block) == utils.KeywordBlocks[p.cfg.ChainID]["first"] {
+	firstBlock := utils.KeywordBlocks[p.cfg.ChainID]["first"]
+	if uint64(state.Block) <= firstBlock {
 		return nil
 	}
 
@@ -106,23 +119,30 @@ func (p *parentBlockHashProcessor) PreBlock(state executor.State[txcontext.TxCon
 		return nil
 	}
 
-	prevBlockHash, err := p.hashProvider.GetBlockHash(state.Block - 1)
-	if err != nil {
-		return fmt.Errorf("cannot get previous block hash: %w", err)
+	startBlock := int(p.lastProcessedBlock) + 1
+
+	for b := startBlock; b <= state.Block; b++ {
+		prevBlockHash, err := p.hashProvider.GetBlockHash(b - 1)
+		if err != nil {
+			return fmt.Errorf("cannot get block hash for block %d: %w", b-1, err)
+		}
+
+		if err = ctx.State.BeginTransaction(utils.PseudoTx); err != nil {
+			return fmt.Errorf("cannot begin transaction: %w", err)
+		}
+
+		var hashError error
+		blockCtx := utils.PrepareBlockCtx(inputEnv, &hashError)
+		blockCtx.BlockNumber = new(big.Int).SetUint64(uint64(b))
+		evm := vm.NewEVM(*blockCtx, ctx.State, chainCfg, p.cfg.VmCfg)
+		err = p.processor.ProcessParentBlockHash(common.Hash(prevBlockHash), evm, ctx.State)
+		if err != nil {
+			return err
+		}
+		if hashError != nil {
+			return fmt.Errorf("hash error while processing parent block hash for block %d: %v", b, hashError)
+		}
 	}
 
-	if err = ctx.State.BeginTransaction(utils.PseudoTx); err != nil {
-		return fmt.Errorf("cannot begin transaction: %w", err)
-	}
-	var hashError error
-	blockCtx := utils.PrepareBlockCtx(inputEnv, &hashError)
-	evm := vm.NewEVM(*blockCtx, ctx.State, chainCfg, p.cfg.VmCfg)
-	err = p.processor.ProcessParentBlockHash(common.Hash(prevBlockHash), evm, ctx.State)
-	if err != nil {
-		return err
-	}
-	if hashError != nil {
-		return fmt.Errorf("hash error while processing parent block hash: %v", err)
-	}
 	return nil
 }

--- a/executor/extension/statedb/parent_block_hash_processor.go
+++ b/executor/extension/statedb/parent_block_hash_processor.go
@@ -47,9 +47,9 @@ func NewParentBlockHashProcessor(cfg *utils.Config) executor.Extension[txcontext
 }
 
 type parentBlockHashProcessor struct {
-	hashProvider db.HashProvider
-	processor    iEvmProcessor
-	cfg          *utils.Config
+	hashProvider       db.HashProvider
+	processor          iEvmProcessor
+	cfg                *utils.Config
 	lastProcessedBlock uint64 // Substate may skip blocks, so we need to track the last processed block to fill the gaps
 	extension.NilExtension[txcontext.TxContext]
 }
@@ -90,7 +90,7 @@ func (p *parentBlockHashProcessor) PreRun(_ executor.State[txcontext.TxContext],
 	p.hashProvider = db.MakeHashProvider(ctx.AidaDb)
 	// initialized the last processed block
 	if p.cfg.First > 0 {
-		p.lastProcessedBlock = utils.KeywordBlocks[p.cfg.ChainID]["first"]
+		p.lastProcessedBlock = p.cfg.First - 1
 	}
 	return nil
 }

--- a/executor/extension/statedb/parent_block_hash_processor.go
+++ b/executor/extension/statedb/parent_block_hash_processor.go
@@ -104,8 +104,8 @@ func (p *parentBlockHashProcessor) PreBlock(state executor.State[txcontext.TxCon
 
 	// We are saving historic block hashes, first block must be skipped because
 	// there is no history at this point
-	firstBlock := utils.KeywordBlocks[p.cfg.ChainID]["first"]
-	if uint64(state.Block) <= firstBlock {
+	chainFirstBlock := utils.KeywordBlocks[p.cfg.ChainID]["first"]
+	if uint64(state.Block) <= chainFirstBlock {
 		return nil
 	}
 
@@ -115,16 +115,18 @@ func (p *parentBlockHashProcessor) PreBlock(state executor.State[txcontext.TxCon
 		return fmt.Errorf("cannot get chain config: %w", err)
 	}
 
+	// Only timestamp of current block is available. For a corner case where first non-empty block is not Prague,
+	// and the next non-empty block is after Prague, backfilling of parent hashes of non-Prague blocks may happen.
 	if !chainCfg.IsPrague(new(big.Int).SetUint64(inputEnv.GetNumber()), inputEnv.GetTimestamp()) {
 		return nil
 	}
 
 	startBlock := int(p.lastProcessedBlock) + 1
 
-	for b := startBlock; b <= state.Block; b++ {
-		prevBlockHash, err := p.hashProvider.GetBlockHash(b - 1)
+	for block := startBlock; block <= int(state.Block); block++ {
+		prevBlockHash, err := p.hashProvider.GetBlockHash(block - 1)
 		if err != nil {
-			return fmt.Errorf("cannot get block hash for block %d: %w", b-1, err)
+			return fmt.Errorf("cannot get block hash for block %d: %w", block-1, err)
 		}
 
 		if err = ctx.State.BeginTransaction(utils.PseudoTx); err != nil {
@@ -133,14 +135,14 @@ func (p *parentBlockHashProcessor) PreBlock(state executor.State[txcontext.TxCon
 
 		var hashError error
 		blockCtx := utils.PrepareBlockCtx(inputEnv, &hashError)
-		blockCtx.BlockNumber = new(big.Int).SetUint64(uint64(b))
+		blockCtx.BlockNumber = new(big.Int).SetUint64(uint64(block))
 		evm := vm.NewEVM(*blockCtx, ctx.State, chainCfg, p.cfg.VmCfg)
 		err = p.processor.ProcessParentBlockHash(common.Hash(prevBlockHash), evm, ctx.State)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot process parent block hash for block %d: %w", block, err)
 		}
 		if hashError != nil {
-			return fmt.Errorf("hash error while processing parent block hash for block %d: %v", b, hashError)
+			return fmt.Errorf("hash error while processing parent block hash for block %d: %v", block, hashError)
 		}
 	}
 

--- a/executor/extension/statedb/parent_block_hash_processor_test.go
+++ b/executor/extension/statedb/parent_block_hash_processor_test.go
@@ -17,6 +17,7 @@
 package statedb
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -142,6 +143,107 @@ func TestParentBlockHashProcessor_PreRunInitializesHashProvider(t *testing.T) {
 	hash, err := hp.(*parentBlockHashProcessor).hashProvider.GetStateRootHash(10)
 	require.NoError(t, err, "hashProvider.GetStateRootHash failed")
 	require.Equal(t, stateRoot.Bytes(), hash.Bytes())
+}
+
+func TestParentBlockHashProcessor_PreBlock_GetBlockHashError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockProvider := db.NewMockHashProvider(ctrl)
+	mockState := state.NewMockStateDB(ctrl)
+	mockProcessor := mocks.NewMockiEvmProcessor(ctrl)
+
+	mockProvider.EXPECT().GetBlockHash(2).Return(types.Hash{}, fmt.Errorf("db error"))
+
+	hashProcessor := parentBlockHashProcessor{
+		hashProvider:       mockProvider,
+		processor:          mockProcessor,
+		cfg:                utils.NewTestConfig(t, utils.HoleskyChainID, 1, 10, false, "Prague"),
+		lastProcessedBlock: 2,
+		NilExtension:       extension.NilExtension[txcontext.TxContext]{},
+	}
+
+	err := hashProcessor.PreBlock(executor.State[txcontext.TxContext]{Block: 3, Data: substateCtx.NewTxContext(&substate.Substate{
+		Env:   &substate.Env{Timestamp: math.MaxUint64},
+		Block: 3,
+	})}, &executor.Context{State: mockState})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot get block hash for block 2")
+}
+
+func TestParentBlockHashProcessor_PreBlock_BeginTransactionError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockProvider := db.NewMockHashProvider(ctrl)
+	mockState := state.NewMockStateDB(ctrl)
+	mockProcessor := mocks.NewMockiEvmProcessor(ctrl)
+
+	hash := types.Hash{123}
+	mockProvider.EXPECT().GetBlockHash(2).Return(hash, nil)
+	mockState.EXPECT().BeginTransaction(uint32(utils.PseudoTx)).Return(fmt.Errorf("tx error"))
+
+	hashProcessor := parentBlockHashProcessor{
+		hashProvider:       mockProvider,
+		processor:          mockProcessor,
+		cfg:                utils.NewTestConfig(t, utils.HoleskyChainID, 1, 10, false, "Prague"),
+		lastProcessedBlock: 2,
+		NilExtension:       extension.NilExtension[txcontext.TxContext]{},
+	}
+
+	err := hashProcessor.PreBlock(executor.State[txcontext.TxContext]{Block: 3, Data: substateCtx.NewTxContext(&substate.Substate{
+		Env:   &substate.Env{Timestamp: math.MaxUint64},
+		Block: 3,
+	})}, &executor.Context{State: mockState})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot begin transaction")
+}
+
+func TestParentBlockHashProcessor_PreBlock_ProcessParentBlockHashError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockProvider := db.NewMockHashProvider(ctrl)
+	mockState := state.NewMockStateDB(ctrl)
+	mockProcessor := mocks.NewMockiEvmProcessor(ctrl)
+
+	hash := types.Hash{123}
+	gomock.InOrder(
+		mockProvider.EXPECT().GetBlockHash(2).Return(hash, nil),
+		mockState.EXPECT().BeginTransaction(uint32(utils.PseudoTx)).Return(nil),
+		mockProcessor.EXPECT().ProcessParentBlockHash(common.Hash(hash), gomock.Any(), gomock.Any()).Return(fmt.Errorf("process error")),
+	)
+
+	hashProcessor := parentBlockHashProcessor{
+		hashProvider:       mockProvider,
+		processor:          mockProcessor,
+		cfg:                utils.NewTestConfig(t, utils.HoleskyChainID, 1, 10, false, "Prague"),
+		lastProcessedBlock: 2,
+		NilExtension:       extension.NilExtension[txcontext.TxContext]{},
+	}
+
+	err := hashProcessor.PreBlock(executor.State[txcontext.TxContext]{Block: 3, Data: substateCtx.NewTxContext(&substate.Substate{
+		Env:   &substate.Env{Timestamp: math.MaxUint64},
+		Block: 3,
+	})}, &executor.Context{State: mockState})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot process parent block hash for block 3")
+}
+
+func TestParentBlockHashProcessor_PreBlock_GetChainConfigError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockProvider := db.NewMockHashProvider(ctrl)
+	mockState := state.NewMockStateDB(ctrl)
+	mockProcessor := mocks.NewMockiEvmProcessor(ctrl)
+
+	hashProcessor := parentBlockHashProcessor{
+		hashProvider:       mockProvider,
+		processor:          mockProcessor,
+		cfg:                &utils.Config{ChainID: utils.ChainID(999999)}, // wrong chain id
+		lastProcessedBlock: 2,
+		NilExtension:       extension.NilExtension[txcontext.TxContext]{},
+	}
+
+	err := hashProcessor.PreBlock(executor.State[txcontext.TxContext]{Block: 3, Data: substateCtx.NewTxContext(&substate.Substate{
+		Env:   &substate.Env{Timestamp: math.MaxUint64},
+		Block: 3,
+	})}, &executor.Context{State: mockState})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot get chain config")
 }
 
 func TestParentBlockHashProcessor_ProcessParentBlockHash(t *testing.T) {

--- a/executor/extension/statedb/parent_block_hash_processor_test.go
+++ b/executor/extension/statedb/parent_block_hash_processor_test.go
@@ -86,6 +86,47 @@ func TestParentBlockHashProcessor_PreBlock(t *testing.T) {
 	require.NoError(t, err, "PreBlock failed")
 }
 
+func TestParentBlockHashProcessor_PreBlock_FillsGapsForSkippedBlocks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockProvider := db.NewMockHashProvider(ctrl)
+	mockState := state.NewMockStateDB(ctrl)
+	mockProcessor := mocks.NewMockiEvmProcessor(ctrl)
+
+	hash4 := types.Hash{4}
+	hash5 := types.Hash{5}
+	hash6 := types.Hash{6}
+
+	// Blocks 4, 5, and 6 must be processed in order to fill the gap
+	gomock.InOrder(
+		mockProvider.EXPECT().GetBlockHash(3).Return(hash4, nil),
+		mockState.EXPECT().BeginTransaction(uint32(utils.PseudoTx)).Return(nil),
+		mockProcessor.EXPECT().ProcessParentBlockHash(common.Hash(hash4), gomock.Any(), gomock.Any()),
+
+		mockProvider.EXPECT().GetBlockHash(4).Return(hash5, nil),
+		mockState.EXPECT().BeginTransaction(uint32(utils.PseudoTx)).Return(nil),
+		mockProcessor.EXPECT().ProcessParentBlockHash(common.Hash(hash5), gomock.Any(), gomock.Any()),
+
+		mockProvider.EXPECT().GetBlockHash(5).Return(hash6, nil),
+		mockState.EXPECT().BeginTransaction(uint32(utils.PseudoTx)).Return(nil),
+		mockProcessor.EXPECT().ProcessParentBlockHash(common.Hash(hash6), gomock.Any(), gomock.Any()),
+	)
+
+	hashProcessor := parentBlockHashProcessor{
+		hashProvider:       mockProvider,
+		processor:          mockProcessor,
+		cfg:                utils.NewTestConfig(t, utils.HoleskyChainID, 1, 10, false, "Prague"),
+		lastProcessedBlock: 3, // Simulate that block 3 was the last processed block
+		NilExtension:       extension.NilExtension[txcontext.TxContext]{},
+	}
+
+	// Jump from block 3 to block 6 — blocks 4, 5 were skipped in substate
+	err := hashProcessor.PreBlock(executor.State[txcontext.TxContext]{Block: 6, Data: substateCtx.NewTxContext(&substate.Substate{
+		Env:   &substate.Env{Timestamp: math.MaxUint64},
+		Block: 6,
+	})}, &executor.Context{State: mockState})
+	require.NoError(t, err, "PreBlock failed")
+}
+
 func TestParentBlockHashProcessor_PreRunInitializesHashProvider(t *testing.T) {
 	cfg := utils.NewTestConfig(t, utils.HoleskyChainID, 1, 10, false, "Prague")
 	hp := NewParentBlockHashProcessor(cfg)

--- a/executor/extension/statedb/parent_block_hash_processor_test.go
+++ b/executor/extension/statedb/parent_block_hash_processor_test.go
@@ -128,6 +128,27 @@ func TestParentBlockHashProcessor_PreBlock_FillsGapsForSkippedBlocks(t *testing.
 	require.NoError(t, err, "PreBlock failed")
 }
 
+func TestParentBlockHashProcessor_PreBlock_SkipsLoopWhenAlreadyProcessed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockProvider := db.NewMockHashProvider(ctrl)
+	mockState := state.NewMockStateDB(ctrl)
+	mockProcessor := mocks.NewMockiEvmProcessor(ctrl)
+
+	hashProcessor := parentBlockHashProcessor{
+		hashProvider:       mockProvider,
+		processor:          mockProcessor,
+		cfg:                utils.NewTestConfig(t, utils.HoleskyChainID, 1, 10, false, "Prague"),
+		lastProcessedBlock: 5, // already past state.Block
+		NilExtension:       extension.NilExtension[txcontext.TxContext]{},
+	}
+
+	err := hashProcessor.PreBlock(executor.State[txcontext.TxContext]{Block: 3, Data: substateCtx.NewTxContext(&substate.Substate{
+		Env:   &substate.Env{Timestamp: math.MaxUint64},
+		Block: 3,
+	})}, &executor.Context{State: mockState})
+	require.NoError(t, err)
+}
+
 func TestParentBlockHashProcessor_PreRunInitializesHashProvider(t *testing.T) {
 	cfg := utils.NewTestConfig(t, utils.HoleskyChainID, 1, 10, false, "Prague")
 	hp := NewParentBlockHashProcessor(cfg)


### PR DESCRIPTION
## Description

The executor iterates over substate records, which only exist for blocks with transactions. Empty blocks are skipped entirely, so Parent hash updater wes never fires for them and the parent hash is never written to the HistoryStorage contract.

This causes a stale value to remain in the ring buffer slot, leading to a storage mismatch when a later transaction references the HistoryStorageAddress account.
Fixes #220 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (changes that do NOT affect functionality)
- [ x Adds or updates testing
- [ ] This change requires a documentation update
