### PR TITLE
Fix sonic ethapi import

### DIFF
--- a/rpc/evm.go
+++ b/rpc/evm.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/0xsoniclabs/aida/state"
 	"github.com/0xsoniclabs/aida/utils"
-	"github.com/0xsoniclabs/sonic/ethapi"
+	"github.com/0xsoniclabs/sonic/api/ethapi"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"

--- a/rpc/evm_test.go
+++ b/rpc/evm_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/0xsoniclabs/aida/state"
 	"github.com/0xsoniclabs/aida/utils"
-	"github.com/0xsoniclabs/sonic/ethapi"
+	"github.com/0xsoniclabs/sonic/api/ethapi"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"


### PR DESCRIPTION
## Description

A [nightly test](https://scala.fantom.network/job/Sonic/job/Aida-Geth-State-Tests/621/console) has been failing due to an import issue of the sonic ethapi package which has been moved in a recent refactor. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)