### PR TITLE
Retire blaze and opera mainnet RPC

### DIFF
--- a/utils/rpc.go
+++ b/utils/rpc.go
@@ -29,7 +29,7 @@ import (
 const (
 	RPCSonicMainnet = "https://rpc.soniclabs.com"
 	RPCOperaMainnet = "https://rpcapi.fantom.network"
-	RPCTestnet      = "https://rpc.blaze.soniclabs.com"
+	RPCTestnet      = "https://rpc.testnet.soniclabs.com"
 )
 
 var ErrRPCUnsupported = fmt.Errorf("chain-id is not supported")


### PR DESCRIPTION
## Description

This PR removes the uses of Blase and Opera mainnet rpc from aida code base.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (changes that do NOT affect functionality)
- [ ] Adds or updates testing
- [ ] This change requires a documentation update
