### PR TITLE
Fix `transactionResult::String` implementation

### DIFF
--- a/executor/transaction_result.go
+++ b/executor/transaction_result.go
@@ -70,7 +70,12 @@ func (r transactionResult) Equal(y txcontext.Receipt) bool {
 }
 
 func (r transactionResult) String() string {
-	return fmt.Sprintf("Status: %v\nBloom: %s\nContract Address: %s\nGas Used: %v\nLogs: %v\n", r.status, string(r.bloom.Bytes()), r.contractAddress, r.gasUsed, r.logs)
+	s := fmt.Sprintf("Status: %v\nBloom: %s\nContract Address: %s\nGas Used: %v\n", r.status, string(r.bloom.Bytes()), r.contractAddress, r.gasUsed)
+	s += "Logs:\n"
+	for i, log := range r.logs {
+		s += fmt.Sprintf("  Log %d: Address: %s, Topics: %v, Data: %s\n", i, log.Address, log.Topics, string(log.Data))
+	}
+	return s
 }
 
 func newTransactionResult(logs []*types.Log, msg *core.Message, msgResult executionResult, err error, origin common.Address) transactionResult {

--- a/executor/transaction_result_test.go
+++ b/executor/transaction_result_test.go
@@ -128,7 +128,7 @@ func TestTransactionResult_String(t *testing.T) {
 		},
 	}
 	out := obj.String()
-	assert.Equal(t, 383, len(out))
+	assert.Equal(t, 517, len(out))
 }
 
 func TestTransactionResult_newTransactionResult(t *testing.T) {


### PR DESCRIPTION
`TestTransactionResult_String` was flaky as the pointers printed by `[]*types.Log` had trimmed leading zeroes, resulting in different length.
This PR updates the `String()` implementation to actually print the content of the log type, and updates the test with the correct number of bytes.

This issue arises only with go 1.26+, not sure why before it was passing